### PR TITLE
Pre-commit hook to use clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,250 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: NextLine
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequiresClause: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth:   -1
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: pb
+    BasedOnStyle:    google
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RequiresClausePosition: OwnLine
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Auto
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v15.0.7
+    hooks:
+    -   id: clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
     -   id: clang-format
         name: clang-format
-        entry: clang-format -i
+        entry: ./hooks/clang-format-hook
         types_or: [c++, c]
         language: system
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,11 @@
 repos:
--   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v15.0.7
+-   repo: local
     hooks:
     -   id: clang-format
+        name: clang-format
+        entry: clang-format -i
+        types_or: [c++, c]
+        language: system
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # IDNA
 
-### Setup
+### Commit setup
 #### Git hooks
-1. Install [pre-commit](https://pre-commit.com/) (a framework to manage pre-commit hooks)
+1. Install [pre-commit](https://pre-commit.com/)
 Using [pip](https://www.w3schools.com/python/python_pip.asp):
 ```bash
 pip install pre-commit

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # IDNA
 
-### Commit setup
-#### Git hooks
+#### Commit setup
+##### Git hooks
 1. Install [pre-commit](https://pre-commit.com/)
 Using [pip](https://www.w3schools.com/python/python_pip.asp):
 ```bash

--- a/README.md
+++ b/README.md
@@ -3,19 +3,21 @@
 #### Commit setup
 ##### Git hooks
 1. Install [pre-commit](https://pre-commit.com/)
-Using [pip](https://www.w3schools.com/python/python_pip.asp):
-```bash
-pip install pre-commit
-```
-Using [homebrew](https://brew.sh/index_pt-br)
-```bash
-brew install pre-commit
-```
+
+    Using [pip](https://www.w3schools.com/python/python_pip.asp):
+    ```bash
+    pip install pre-commit
+    ```
+    Using [homebrew](https://brew.sh/index_pt-br)
+    ```bash
+    brew install pre-commit
+    ```
 
 2. Use `pre-commit` to install local hooks
-Run this command in the root of this repo
-```bash
-pre-commit install
-```
+
+    Run the following command in the root of this repo
+    ```bash
+    pre-commit install
+    ```
 
 You are all set for the hooks!

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# idna
+# IDNA
+
+### Setup
+#### Git hooks
+1. Install [pre-commit](https://pre-commit.com/) (a framework to manage pre-commit hooks)
+Using [pip](https://www.w3schools.com/python/python_pip.asp):
+```bash
+pip install pre-commit
+```
+Using [homebrew](https://brew.sh/index_pt-br)
+```bash
+brew install pre-commit
+```
+
+2. Use `pre-commit` to install local hooks
+Run this command in the root of this repo
+```bash
+pre-commit install
+```
+
+You are all set for the hooks!

--- a/hooks/clang-format-hook
+++ b/hooks/clang-format-hook
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+for file in `git diff-index --cached --name-only HEAD | grep -iE '\.(cpp|cc|c|h|hpp)$'`
+do
+    clang-format -i "${file}"
+    git add "${file}"
+done

--- a/include/ada/idna/punycode.h
+++ b/include/ada/idna/punycode.h
@@ -5,10 +5,10 @@
 #include <string_view>
 namespace ada::idna {
 
-bool punycode_to_utf32(std::string_view input, std::u32string & out);
+bool punycode_to_utf32(std::string_view input, std::u32string& out);
 bool verify_punycode(std::string_view input);
 bool utf32_to_punycode(std::u32string_view input, std::string& out);
 
-}
+}  // namespace ada::idna
 
-#endif // ADA_IDNA_PUNYCODE_H
+#endif  // ADA_IDNA_PUNYCODE_H

--- a/include/ada/idna/to_ascii.h
+++ b/include/ada/idna/to_ascii.h
@@ -6,13 +6,13 @@
 #include <string_view>
 
 namespace ada::idna {
-    // Converts a domain (e.g., www.google.com) possibly containing international characters
-    // to an ascii domain (with punycode). It will not do percent decoding: percent decoding
-    // should be done prior to calling this function. We do not remove tabs and spaces, they
-    // should have been removed prior to calling this function. We also do not trim control
-    // characters. We also assume that the input is not empty.
-    // We return "" on error. For now.
-    std::string to_ascii(std::string_view ut8_string);
-}
+// Converts a domain (e.g., www.google.com) possibly containing international
+// characters to an ascii domain (with punycode). It will not do percent
+// decoding: percent decoding should be done prior to calling this function. We
+// do not remove tabs and spaces, they should have been removed prior to calling
+// this function. We also do not trim control characters. We also assume that
+// the input is not empty. We return "" on error. For now.
+std::string to_ascii(std::string_view ut8_string);
+}  // namespace ada::idna
 
-#endif // ADA_IDNA_TO_ASCII_H
+#endif  // ADA_IDNA_TO_ASCII_H

--- a/include/ada/idna/unicode_transcoding.h
+++ b/include/ada/idna/unicode_transcoding.h
@@ -14,6 +14,6 @@ size_t utf32_length_from_utf8(const char* buf, size_t len);
 
 size_t utf32_to_utf8(const char32_t* buf, size_t len, char* utf8_output);
 
-}
+}  // namespace ada::idna
 
-#endif // ADA_IDNA_UNICODE_TRANSCODING_H
+#endif  // ADA_IDNA_UNICODE_TRANSCODING_H

--- a/src/idna.cpp
+++ b/src/idna.cpp
@@ -1,3 +1,3 @@
 #include "punycode.cpp"
-#include "unicode_transcoding.cpp"
 #include "to_ascii.cpp"
+#include "unicode_transcoding.cpp"

--- a/src/punycode.cpp
+++ b/src/punycode.cpp
@@ -13,15 +13,13 @@ constexpr int32_t initial_bias = 72;
 constexpr uint32_t initial_n = 128;
 
 static constexpr int32_t char_to_digit_value(char value) {
-  if (value >= 'a' && value <= 'z')
-    return value - 'a';
-  if (value >= '0' && value <= '9')
-    return value - '0' + 26;
+  if (value >= 'a' && value <= 'z') return value - 'a';
+  if (value >= '0' && value <= '9') return value - '0' + 26;
   return -1;
 }
 
 static constexpr char digit_to_char(int32_t digit) {
-    return digit < 26 ? digit + 97 : digit + 22;
+  return digit < 26 ? digit + 97 : digit + 22;
 }
 
 static constexpr int32_t adapt(int32_t d, int32_t n, bool firsttime) {
@@ -99,7 +97,6 @@ bool punycode_to_utf32(std::string_view input, std::u32string &out) {
 
   return true;
 }
-
 
 bool verify_punycode(std::string_view input) {
   size_t written_out{0};
@@ -182,8 +179,7 @@ bool utf32_to_punycode(std::u32string_view input, std::string &out) {
   while (h < input.size()) {
     uint32_t m = 0x10FFFF;
     for (auto code_point : input) {
-      if (code_point >= n && code_point < m)
-        m = code_point;
+      if (code_point >= n && code_point < m) m = code_point;
     }
 
     if ((m - n) > (0x7fffffff - d) / (h + 1)) {
@@ -221,4 +217,4 @@ bool utf32_to_punycode(std::u32string_view input, std::string &out) {
   return true;
 }
 
-} // namespace ada::idna
+}  // namespace ada::idna

--- a/src/to_ascii.cpp
+++ b/src/to_ascii.cpp
@@ -1,8 +1,9 @@
 #include "ada/idna/to_ascii.h"
-#include "ada/idna/punycode.h"
-#include "ada/idna/unicode_transcoding.h"
 
 #include <cstdint>
+
+#include "ada/idna/punycode.h"
+#include "ada/idna/unicode_transcoding.h"
 
 namespace ada::idna {
 
@@ -15,33 +16,46 @@ bool begins_with(std::u32string_view view, std::u32string_view prefix) {
 
 // We return "" on error. For now.
 std::string to_ascii(std::string_view ut8_string) {
-  // If the string is pure ascii, then **we do not need** to convert to UTF-32 and could
-  // use a faster path where we only do verify_punycode where needed. Though we may need
-  // to do mapping and check for forbidden characters.
+  // If the string is pure ascii, then **we do not need** to convert to
+  // UTF-32 and could use a faster path where we only do verify_punycode
+  // where needed. Though we may need to do mapping and check for
+  // forbidden characters.
   static const std::string error = "";
   // We convert to UTF-32
   size_t utf32_length =
       ada::idna::utf32_length_from_utf8(ut8_string.data(), ut8_string.size());
   std::u32string utf32(utf32_length, '\0');
-  // To do: utf8_to_utf32 will return zero if the input is invalid UTF-8, we should
-  // check.
+  // To do: utf8_to_utf32 will return zero if the input is invalid
+  // UTF-8, we should check.
   ada::idna::utf8_to_utf32(ut8_string.data(), ut8_string.size(), utf32.data());
 
-  // Here we would do extra work such as mapping and so forth. Here is what we need to do:
+  // Here we would do extra work such as mapping and so forth. Here is
+  // what we need to do:
   //
-  //  * [Map](https://www.unicode.org/reports/tr46/#ProcessingStepMap). For each code point in the domain_name string, look up the status value in Section 5, [IDNA Mapping Table](https://www.unicode.org/reports/tr46/#IDNA_Mapping_Table), and take the following actions:
-  //    * disallowed: Leave the code point unchanged in the string, and record that there was an error.
-  //    * ignored: Remove the code point from the string. This is equivalent to mapping the code point to an empty string.
-  //    * mapped: Replace the code point in the string by the value for the mapping in Section 5, [IDNA Mapping Table](https://www.unicode.org/reports/tr46/#IDNA_Mapping_Table).
+  //  * [Map](https://www.unicode.org/reports/tr46/#ProcessingStepMap).
+  //  For each code point in the domain_name string, look up the status
+  //  value in Section 5, [IDNA Mapping
+  //  Table](https://www.unicode.org/reports/tr46/#IDNA_Mapping_Table),
+  //  and take the following actions:
+  //    * disallowed: Leave the code point unchanged in the string, and
+  //    record that there was an error.
+  //    * ignored: Remove the code point from the string. This is
+  //    equivalent to mapping the code point to an empty string.
+  //    * mapped: Replace the code point in the string by the value for
+  //    the mapping in Section 5, [IDNA Mapping
+  //    Table](https://www.unicode.org/reports/tr46/#IDNA_Mapping_Table).
   //    * valid: Leave the code point unchanged in the string.
-  //  * [Normalize](https://www.unicode.org/reports/tr46/#ProcessingStepNormalize). Normalize 
-  //     the domain_name string to Unicode Normalization Form C. See https://dev.w3.org/cvsweb/charlint/charlint.pl?rev=1.28;content-type=text%2Fplain for a Perl script that does it.
+  //  * [Normalize](https://www.unicode.org/reports/tr46/#ProcessingStepNormalize). Normalize
+  //     the domain_name string to Unicode Normalization Form C. See
+  //     https://dev.w3.org/cvsweb/charlint/charlint.pl?rev=1.28;content-type=text%2Fplain
+  //     for a Perl script that does it.
   ////////////////////////////////////////////////////
   // TODO: Implement mapping *and* normalization.
   ////////////////////////////////////////////////////
   std::string out;
   size_t label_start = 0;
-  //  * [Break](https://www.unicode.org/reports/tr46/#ProcessingStepBreak). Break the string into labels at U+002E ( . ) FULL STOP.
+  //  * [Break](https://www.unicode.org/reports/tr46/#ProcessingStepBreak).
+  //  Break the string into labels at U+002E ( . ) FULL STOP.
 
   while (label_start != utf32.size()) {
     size_t loc_dot = utf32.find('.', label_start);
@@ -58,11 +72,26 @@ std::string to_ascii(std::string_view ut8_string) {
                begins_with(label_view, U"XN--") ||
                begins_with(label_view, U"Xn--") ||
                begins_with(label_view, U"xN--")) {
-      //    * [If the label starts with “xn--”](https://www.unicode.org/reports/tr46/#ProcessingStepPunycode):
-      //      * Attempt to convert the rest of the label to Unicode according to Punycode [[RFC3492 (https://www.unicode.org/reports/tr46/#RFC3492)]. If that conversion fails, record that there was an error, and continue with the next label. Otherwise replace the original label in the string by the results of the conversion.
-      //      * Verify that the label meets the validity criteria in Section 4.1, [Validity Criteria](https://www.unicode.org/reports/tr46/#Validity_Criteria) for Nontransitional Processing. If any of the validity criteria are not satisfied, record that there was an error.
+      //    * [If the label starts with
+      //    “xn--”](https://www.unicode.org/reports/tr46/#ProcessingStepPunycode):
+      //      * Attempt to convert the rest of the label
+      //      to Unicode according to Punycode [[RFC3492
+      //      (https://www.unicode.org/reports/tr46/#RFC3492)].
+      //      If that conversion fails, record that
+      //      there was an error, and continue with the
+      //      next label. Otherwise replace the original
+      //      label in the string by the results of the
+      //      conversion.
+      //      * Verify that the label meets the validity
+      //      criteria in Section 4.1, [Validity
+      //      Criteria](https://www.unicode.org/reports/tr46/#Validity_Criteria)
+      //      for Nontransitional Processing. If any of
+      //      the validity criteria are not satisfied,
+      //      record that there was an error.
       ////////////////////////////////////////////////////
-      // TODO: current code merely verifies that we have proper punycode. But we should decode and verify the cotent.
+      // TODO: current code merely verifies that we have
+      // proper punycode. But we should decode and
+      // verify the cotent.
       ////////////////////////////////////////////////////
       for (char32_t c : label_view) {
         if (c >= 0x80) {
@@ -76,10 +105,18 @@ std::string to_ascii(std::string_view ut8_string) {
         return error;
       }
     } else {
-      //    * [If the label does not start with “xn--”](https://www.unicode.org/reports/tr46/#ProcessingStepNonPunycode):
-      //  Verify that the label meets the validity criteria in Section 4.1, [Validity Criteria](https://www.unicode.org/reports/tr46/#Validity_Criteria) for the input Processing choice (Transitional or Nontransitional). If any of the validity criteria are not satisfied, record that there was an error.
+      //    * [If the label does not start with
+      //    “xn--”](https://www.unicode.org/reports/tr46/#ProcessingStepNonPunycode):
+      //  Verify that the label meets the validity
+      //  criteria in Section 4.1, [Validity
+      //  Criteria](https://www.unicode.org/reports/tr46/#Validity_Criteria)
+      //  for the input Processing choice (Transitional
+      //  or Nontransitional). If any of the validity
+      //  criteria are not satisfied, record that there
+      //  was an error.
       ////////////////////////////////////////////////////
-      // TODO: current code merely encodes to punycode but we should also check the validity criteria.
+      // TODO: current code merely encodes to punycode
+      // but we should also check the validity criteria.
       ////////////////////////////////////////////////////
       ada::idna::utf32_to_punycode(label_view, out);
     }
@@ -89,4 +126,4 @@ std::string to_ascii(std::string_view ut8_string) {
   }
   return out;
 }
-} // namespace ada::idna
+}  // namespace ada::idna

--- a/src/unicode_transcoding.cpp
+++ b/src/unicode_transcoding.cpp
@@ -1,15 +1,17 @@
 
 #include "ada/idna/unicode_transcoding.h"
+
 #include <cstring>
 namespace ada::idna {
 
 size_t utf8_to_utf32(const char* buf, size_t len, char32_t* utf32_output) {
- const uint8_t *data = reinterpret_cast<const uint8_t *>(buf);
+  const uint8_t* data = reinterpret_cast<const uint8_t*>(buf);
   size_t pos = 0;
   char32_t* start{utf32_output};
   while (pos < len) {
     // try to convert the next block of 16 ASCII bytes
-    if (pos + 16 <= len) { // if it is safe to read 16 more bytes, check that they are ascii
+    if (pos + 16 <= len) {  // if it is safe to read 16 more
+                            // bytes, check that they are ascii
       uint64_t v1;
       std::memcpy(&v1, data + pos, sizeof(uint64_t));
       uint64_t v2;
@@ -17,55 +19,79 @@ size_t utf8_to_utf32(const char* buf, size_t len, char32_t* utf32_output) {
       uint64_t v{v1 | v2};
       if ((v & 0x8080808080808080) == 0) {
         size_t final_pos = pos + 16;
-        while(pos < final_pos) {
+        while (pos < final_pos) {
           *utf32_output++ = char32_t(buf[pos]);
           pos++;
         }
         continue;
       }
     }
-    uint8_t leading_byte = data[pos]; // leading byte
+    uint8_t leading_byte = data[pos];  // leading byte
     if (leading_byte < 0b10000000) {
       // converting one ASCII byte !!!
       *utf32_output++ = char32_t(leading_byte);
       pos++;
     } else if ((leading_byte & 0b11100000) == 0b11000000) {
       // We have a two-byte UTF-8
-      if(pos + 1 >= len) { return 0; } // minimal bound checking
-      if ((data[pos + 1] & 0b11000000) != 0b10000000) { return 0; }
+      if (pos + 1 >= len) {
+        return 0;
+      }  // minimal bound checking
+      if ((data[pos + 1] & 0b11000000) != 0b10000000) {
+        return 0;
+      }
       // range check
-      uint32_t code_point = (leading_byte & 0b00011111) << 6 | (data[pos + 1] & 0b00111111);
-      if (code_point < 0x80 || 0x7ff < code_point) { return 0; }
+      uint32_t code_point =
+          (leading_byte & 0b00011111) << 6 | (data[pos + 1] & 0b00111111);
+      if (code_point < 0x80 || 0x7ff < code_point) {
+        return 0;
+      }
       *utf32_output++ = char32_t(code_point);
       pos += 2;
     } else if ((leading_byte & 0b11110000) == 0b11100000) {
       // We have a three-byte UTF-8
-      if(pos + 2 >= len) { return 0; } // minimal bound checking
+      if (pos + 2 >= len) {
+        return 0;
+      }  // minimal bound checking
 
-      if ((data[pos + 1] & 0b11000000) != 0b10000000) { return 0; }
-      if ((data[pos + 2] & 0b11000000) != 0b10000000) { return 0; }
+      if ((data[pos + 1] & 0b11000000) != 0b10000000) {
+        return 0;
+      }
+      if ((data[pos + 2] & 0b11000000) != 0b10000000) {
+        return 0;
+      }
       // range check
       uint32_t code_point = (leading_byte & 0b00001111) << 12 |
-                   (data[pos + 1] & 0b00111111) << 6 |
-                   (data[pos + 2] & 0b00111111);
+                            (data[pos + 1] & 0b00111111) << 6 |
+                            (data[pos + 2] & 0b00111111);
       if (code_point < 0x800 || 0xffff < code_point ||
           (0xd7ff < code_point && code_point < 0xe000)) {
         return 0;
       }
       *utf32_output++ = char32_t(code_point);
       pos += 3;
-    } else if ((leading_byte & 0b11111000) == 0b11110000) { // 0b11110000
+    } else if ((leading_byte & 0b11111000) == 0b11110000) {  // 0b11110000
       // we have a 4-byte UTF-8 word.
-      if(pos + 3 >= len) { return 0; } // minimal bound checking
-      if ((data[pos + 1] & 0b11000000) != 0b10000000) { return 0; }
-      if ((data[pos + 2] & 0b11000000) != 0b10000000) { return 0; }
-      if ((data[pos + 3] & 0b11000000) != 0b10000000) { return 0; }
+      if (pos + 3 >= len) {
+        return 0;
+      }  // minimal bound checking
+      if ((data[pos + 1] & 0b11000000) != 0b10000000) {
+        return 0;
+      }
+      if ((data[pos + 2] & 0b11000000) != 0b10000000) {
+        return 0;
+      }
+      if ((data[pos + 3] & 0b11000000) != 0b10000000) {
+        return 0;
+      }
 
       // range check
-      uint32_t code_point =
-          (leading_byte & 0b00000111) << 18 | (data[pos + 1] & 0b00111111) << 12 |
-          (data[pos + 2] & 0b00111111) << 6 | (data[pos + 3] & 0b00111111);
-      if (code_point <= 0xffff || 0x10ffff < code_point) { return 0; }
+      uint32_t code_point = (leading_byte & 0b00000111) << 18 |
+                            (data[pos + 1] & 0b00111111) << 12 |
+                            (data[pos + 2] & 0b00111111) << 6 |
+                            (data[pos + 3] & 0b00111111);
+      if (code_point <= 0xffff || 0x10ffff < code_point) {
+        return 0;
+      }
       *utf32_output++ = char32_t(code_point);
       pos += 4;
     } else {
@@ -77,77 +103,94 @@ size_t utf8_to_utf32(const char* buf, size_t len, char32_t* utf32_output) {
 
 size_t utf8_length_from_utf32(const char32_t* buf, size_t len) {
   // We are not BOM aware.
-  const uint32_t * p = reinterpret_cast<const uint32_t *>(buf);
+  const uint32_t* p = reinterpret_cast<const uint32_t*>(buf);
   size_t counter{0};
-  for(size_t i = 0; i < len; i++) {
+  for (size_t i = 0; i < len; i++) {
     /** ASCII **/
-    if(p[i] <= 0x7F) { counter++; }
+    if (p[i] <= 0x7F) {
+      counter++;
+    }
     /** two-byte **/
-    else if(p[i] <= 0x7FF) { counter += 2; }
+    else if (p[i] <= 0x7FF) {
+      counter += 2;
+    }
     /** three-byte **/
-    else if(p[i] <= 0xFFFF) { counter += 3; }
+    else if (p[i] <= 0xFFFF) {
+      counter += 3;
+    }
     /** four-bytes **/
-    else { counter += 4; }
+    else {
+      counter += 4;
+    }
   }
   return counter;
 }
 
 size_t utf32_length_from_utf8(const char* buf, size_t len) {
-    const int8_t * p = reinterpret_cast<const int8_t *>(buf);
-    size_t counter{0};
-    for(size_t i = 0; i < len; i++) {
-        // -65 is 0b10111111, anything larger in two-complement's should start a new code point.
-        if(p[i] > -65) { counter++; }
+  const int8_t* p = reinterpret_cast<const int8_t*>(buf);
+  size_t counter{0};
+  for (size_t i = 0; i < len; i++) {
+    // -65 is 0b10111111, anything larger in two-complement's
+    // should start a new code point.
+    if (p[i] > -65) {
+      counter++;
     }
-    return counter;
+  }
+  return counter;
 }
 
 size_t utf32_to_utf8(const char32_t* buf, size_t len, char* utf8_output) {
-  const uint32_t *data = reinterpret_cast<const uint32_t *>(buf);
+  const uint32_t* data = reinterpret_cast<const uint32_t*>(buf);
   size_t pos = 0;
   char* start{utf8_output};
   while (pos < len) {
     // try to convert the next block of 2 ASCII characters
-    if (pos + 2 <= len) { // if it is safe to read 8 more bytes, check that they are ascii
+    if (pos + 2 <= len) {  // if it is safe to read 8 more
+                           // bytes, check that they are ascii
       uint64_t v;
       std::memcpy(&v, data + pos, sizeof(uint64_t));
       if ((v & 0xFFFFFF80FFFFFF80) == 0) {
         *utf8_output++ = char(buf[pos]);
-				*utf8_output++ = char(buf[pos+1]);
+        *utf8_output++ = char(buf[pos + 1]);
         pos += 2;
         continue;
       }
     }
     uint32_t word = data[pos];
-    if((word & 0xFFFFFF80)==0) {
+    if ((word & 0xFFFFFF80) == 0) {
       // will generate one UTF-8 bytes
       *utf8_output++ = char(word);
       pos++;
-    } else if((word & 0xFFFFF800)==0) {
+    } else if ((word & 0xFFFFF800) == 0) {
       // will generate two UTF-8 bytes
       // we have 0b110XXXXX 0b10XXXXXX
-      *utf8_output++ = char((word>>6) | 0b11000000);
+      *utf8_output++ = char((word >> 6) | 0b11000000);
       *utf8_output++ = char((word & 0b111111) | 0b10000000);
       pos++;
-    } else if((word & 0xFFFF0000)==0) {
+    } else if ((word & 0xFFFF0000) == 0) {
       // will generate three UTF-8 bytes
       // we have 0b1110XXXX 0b10XXXXXX 0b10XXXXXX
-			if (word >= 0xD800 && word <= 0xDFFF) { return 0; }
-      *utf8_output++ = char((word>>12) | 0b11100000);
-      *utf8_output++ = char(((word>>6) & 0b111111) | 0b10000000);
+      if (word >= 0xD800 && word <= 0xDFFF) {
+        return 0;
+      }
+      *utf8_output++ = char((word >> 12) | 0b11100000);
+      *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
       *utf8_output++ = char((word & 0b111111) | 0b10000000);
       pos++;
     } else {
       // will generate four UTF-8 bytes
-      // we have 0b11110XXX 0b10XXXXXX 0b10XXXXXX 0b10XXXXXX
-			if (word > 0x10FFFF) { return 0; }
-      *utf8_output++ = char((word>>18) | 0b11110000);
-      *utf8_output++ = char(((word>>12) & 0b111111) | 0b10000000);
-      *utf8_output++ = char(((word>>6) & 0b111111) | 0b10000000);
+      // we have 0b11110XXX 0b10XXXXXX 0b10XXXXXX
+      // 0b10XXXXXX
+      if (word > 0x10FFFF) {
+        return 0;
+      }
+      *utf8_output++ = char((word >> 18) | 0b11110000);
+      *utf8_output++ = char(((word >> 12) & 0b111111) | 0b10000000);
+      *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
       *utf8_output++ = char((word & 0b111111) | 0b10000000);
-      pos ++;
+      pos++;
     }
   }
   return utf8_output - start;
 }
-}
+}  // namespace ada::idna

--- a/tests/punycode_tests.cpp
+++ b/tests/punycode_tests.cpp
@@ -1,12 +1,12 @@
-#include "ada/idna/punycode.h"
-#include "ada/idna/unicode_transcoding.h"
-
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <iostream>
+
+#include "ada/idna/punycode.h"
+#include "ada/idna/unicode_transcoding.h"
 
 bool file_exists(std::string_view filename) {
   namespace fs = std::filesystem;
@@ -21,65 +21,92 @@ bool file_exists(std::string_view filename) {
 }
 
 std::string read_file(std::string filename) {
-    constexpr auto read_size = std::size_t(4096);
-    auto stream = std::ifstream(filename.c_str());
-    stream.exceptions(std::ios_base::badbit);
-    auto out = std::string();
-    auto buf = std::string(read_size, '\0');
-    while (stream.read(& buf[0], read_size)) {
-        out.append(buf, 0, stream.gcount());
-    }
+  constexpr auto read_size = std::size_t(4096);
+  auto stream = std::ifstream(filename.c_str());
+  stream.exceptions(std::ios_base::badbit);
+  auto out = std::string();
+  auto buf = std::string(read_size, '\0');
+  while (stream.read(&buf[0], read_size)) {
     out.append(buf, 0, stream.gcount());
-    return out;
+  }
+  out.append(buf, 0, stream.gcount());
+  return out;
 }
 
 std::vector<std::string> split_string(const std::string& str) {
-    auto result = std::vector<std::string>{};
-    auto ss = std::stringstream{str};
-    for (std::string line; std::getline(ss, line, '\n');) { result.push_back(line); }
-    return result;
+  auto result = std::vector<std::string>{};
+  auto ss = std::stringstream{str};
+  for (std::string line; std::getline(ss, line, '\n');) {
+    result.push_back(line);
+  }
+  return result;
 }
 
 bool test(std::string ut8_string, std::string puny_string) {
-    std::cout << "processing " << puny_string << std::endl;
-    // first check that we can go to UTF-32 and and back.
-    size_t utf32_length = ada::idna::utf32_length_from_utf8(ut8_string.data(), ut8_string.size());
-    std::u32string utf32(utf32_length, '\0');
-    ada::idna::utf8_to_utf32(ut8_string.data(), ut8_string.size(), utf32.data());
-    std::string tmp(ut8_string.size(), '\0');
-    ada::idna::utf32_to_utf8(utf32.data(), utf32_length, tmp.data());
-    if(tmp != ut8_string) { std::cout << "bad utf-8 <==> utf-32 transcoding" << std::endl; return false; }
-    std::string puny;
-    bool is_ok1 = ada::idna::utf32_to_punycode(utf32, puny);
-    if(! is_ok1) { std::cout << "bad utf-32 => punycode transcoding" << std::endl; return false; }
-    if(puny != puny_string) { std::cout << "punycode mismatch" << std::endl; return false; }
-    std::u32string utf32back;
-    bool is_ok2 = ada::idna::punycode_to_utf32(puny, utf32back);
-    if(! is_ok2) { std::cout << "bad punycode => utf-32 transcoding" << std::endl; return false; }
-    // see if we can go back
-    std::string punyback;
-    bool is_ok3 = ada::idna::utf32_to_punycode(utf32back, punyback);
-    if((! is_ok3) || (punyback != puny)) { std::cout << "bad punycode => utf-32 => punycode transcoding" << std::endl; return false; }
-    size_t utf8_length = ada::idna::utf8_length_from_utf32(utf32back.data(), utf32back.size());
-    std::string finalutf8(utf8_length, '\0');
-    ada::idna::utf32_to_utf8(utf32back.data(), utf32back.size(), finalutf8.data());
-    if(finalutf8 != ut8_string) { std::cout << "bad roundtrip utf8 => utf8 transcoding" << std::endl; return false; }
-    return true;
+  std::cout << "processing " << puny_string << std::endl;
+  // first check that we can go to UTF-32 and and back.
+  size_t utf32_length =
+      ada::idna::utf32_length_from_utf8(ut8_string.data(), ut8_string.size());
+  std::u32string utf32(utf32_length, '\0');
+  ada::idna::utf8_to_utf32(ut8_string.data(), ut8_string.size(), utf32.data());
+  std::string tmp(ut8_string.size(), '\0');
+  ada::idna::utf32_to_utf8(utf32.data(), utf32_length, tmp.data());
+  if (tmp != ut8_string) {
+    std::cout << "bad utf-8 <==> utf-32 transcoding" << std::endl;
+    return false;
+  }
+  std::string puny;
+  bool is_ok1 = ada::idna::utf32_to_punycode(utf32, puny);
+  if (!is_ok1) {
+    std::cout << "bad utf-32 => punycode transcoding" << std::endl;
+    return false;
+  }
+  if (puny != puny_string) {
+    std::cout << "punycode mismatch" << std::endl;
+    return false;
+  }
+  std::u32string utf32back;
+  bool is_ok2 = ada::idna::punycode_to_utf32(puny, utf32back);
+  if (!is_ok2) {
+    std::cout << "bad punycode => utf-32 transcoding" << std::endl;
+    return false;
+  }
+  // see if we can go back
+  std::string punyback;
+  bool is_ok3 = ada::idna::utf32_to_punycode(utf32back, punyback);
+  if ((!is_ok3) || (punyback != puny)) {
+    std::cout << "bad punycode => utf-32 => punycode transcoding" << std::endl;
+    return false;
+  }
+  size_t utf8_length =
+      ada::idna::utf8_length_from_utf32(utf32back.data(), utf32back.size());
+  std::string finalutf8(utf8_length, '\0');
+  ada::idna::utf32_to_utf8(utf32back.data(), utf32back.size(),
+                           finalutf8.data());
+  if (finalutf8 != ut8_string) {
+    std::cout << "bad roundtrip utf8 => utf8 transcoding" << std::endl;
+    return false;
+  }
+  return true;
 }
 
+int main(int argc, char** argv) {
+  std::string filename = "utf8_punycode_alternating.txt";
+  if (argc > 1) {
+    filename = argv[1];
+  }
 
-
-int main(int argc, char **argv) {
-    std::string filename = "utf8_punycode_alternating.txt";
-    if(argc>1) { filename = argv[1]; }
-    
-    if(!file_exists(filename)) { return EXIT_FAILURE; }
-    std::string buffer = read_file(filename);
-    std::vector<std::string> lines = split_string(buffer);
-    for(size_t i = 0; i + 1 < lines.size(); i+=2) {
-        std::string ut8_string = lines[i];
-        std::string puny_string = lines[i+1];
-        if(!test(ut8_string, puny_string)) { return EXIT_FAILURE; }
+  if (!file_exists(filename)) {
+    return EXIT_FAILURE;
+  }
+  std::string buffer = read_file(filename);
+  std::vector<std::string> lines = split_string(buffer);
+  for (size_t i = 0; i + 1 < lines.size(); i += 2) {
+    std::string ut8_string = lines[i];
+    std::string puny_string = lines[i + 1];
+    if (!test(ut8_string, puny_string)) {
+      return EXIT_FAILURE;
     }
-    return EXIT_SUCCESS;
+  }
+  return EXIT_SUCCESS;
 }

--- a/tests/to_ascii_tests.cpp
+++ b/tests/to_ascii_tests.cpp
@@ -1,13 +1,13 @@
-#include "ada/idna/punycode.h"
-#include "ada/idna/to_ascii.h"
-#include "ada/idna/unicode_transcoding.h"
-
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <iostream>
+
+#include "ada/idna/punycode.h"
+#include "ada/idna/to_ascii.h"
+#include "ada/idna/unicode_transcoding.h"
 
 bool file_exists(std::string_view filename) {
   namespace fs = std::filesystem;
@@ -22,62 +22,72 @@ bool file_exists(std::string_view filename) {
 }
 
 std::string read_file(std::string filename) {
-    constexpr auto read_size = std::size_t(4096);
-    auto stream = std::ifstream(filename.c_str());
-    stream.exceptions(std::ios_base::badbit);
-    auto out = std::string();
-    auto buf = std::string(read_size, '\0');
-    while (stream.read(& buf[0], read_size)) {
-        out.append(buf, 0, stream.gcount());
-    }
+  constexpr auto read_size = std::size_t(4096);
+  auto stream = std::ifstream(filename.c_str());
+  stream.exceptions(std::ios_base::badbit);
+  auto out = std::string();
+  auto buf = std::string(read_size, '\0');
+  while (stream.read(&buf[0], read_size)) {
     out.append(buf, 0, stream.gcount());
-    return out;
+  }
+  out.append(buf, 0, stream.gcount());
+  return out;
 }
 
 std::vector<std::string> split_string(const std::string& str) {
-    auto result = std::vector<std::string>{};
-    auto ss = std::stringstream{str};
-    for (std::string line; std::getline(ss, line, '\n');) { result.push_back(line); }
-    return result;
+  auto result = std::vector<std::string>{};
+  auto ss = std::stringstream{str};
+  for (std::string line; std::getline(ss, line, '\n');) {
+    result.push_back(line);
+  }
+  return result;
 }
 
 bool test(std::string ut8_string, std::string puny_string) {
-    std::cout << "processing " << puny_string << std::endl;
-    auto processed = ada::idna::to_ascii(ut8_string);
-    if(processed != puny_string) {
-      std::cout << "got " << processed << std::endl;
-      std::cout << "expected " << puny_string << std::endl;
-      return false;
-    }
-    return true;
+  std::cout << "processing " << puny_string << std::endl;
+  auto processed = ada::idna::to_ascii(ut8_string);
+  if (processed != puny_string) {
+    std::cout << "got " << processed << std::endl;
+    std::cout << "expected " << puny_string << std::endl;
+    return false;
+  }
+  return true;
 }
 
+int main(int argc, char** argv) {
+  std::string filename = "to_ascii_alternating.txt";
+  if (argc > 1) {
+    filename = argv[1];
+  }
 
+  if (!file_exists(filename)) {
+    return EXIT_FAILURE;
+  }
+  std::string buffer = read_file(filename);
+  std::vector<std::string> lines = split_string(buffer);
+  for (size_t i = 0; i + 1 < lines.size(); i += 2) {
+    std::string ut8_string = lines[i];
+    std::string puny_string = lines[i + 1];
+    if (!test(ut8_string, puny_string)) {
+      return EXIT_FAILURE;
+    }
+  }
+  filename = "to_ascii_invalid.txt";
+  if (argc > 2) {
+    filename = argv[2];
+  }
 
-int main(int argc, char **argv) {
-    std::string filename = "to_ascii_alternating.txt";
-    if(argc>1) { filename = argv[1]; }
-    
-    if(!file_exists(filename)) { return EXIT_FAILURE; }
-    std::string buffer = read_file(filename);
-    std::vector<std::string> lines = split_string(buffer);
-    for(size_t i = 0; i + 1 < lines.size(); i+=2) {
-        std::string ut8_string = lines[i];
-        std::string puny_string = lines[i+1];
-        if(!test(ut8_string, puny_string)) { return EXIT_FAILURE; }
+  if (!file_exists(filename)) {
+    return EXIT_FAILURE;
+  }
+  buffer = read_file(filename);
+  lines = split_string(buffer);
+  for (size_t i = 0; i < lines.size(); i++) {
+    std::string ut8_string = lines[i];
+    if (!ada::idna::to_ascii(ut8_string).empty()) {
+      std::cout << "Should have failed: " << ut8_string << std::endl;
+      return EXIT_FAILURE;
     }
-    filename = "to_ascii_invalid.txt";
-    if(argc>2) { filename = argv[2]; }
-    
-    if(!file_exists(filename)) { return EXIT_FAILURE; }
-    buffer = read_file(filename);
-    lines = split_string(buffer);
-    for(size_t i = 0; i < lines.size(); i++) {
-        std::string ut8_string = lines[i];
-        if(!ada::idna::to_ascii(ut8_string).empty()) {
-          std::cout << "Should have failed: " << ut8_string << std::endl;
-          return EXIT_FAILURE;
-        }
-    }
-    return EXIT_SUCCESS;
+  }
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Hello! I am proposing to use **clang-format** as a pre-commit hook.
For this I used the [pre-commit](https://pre-commit.com/) micro framework, but I can remove it and use simple 'cp' commands if you think would be better. I also added usage details in the readme. 
For this clang-format configuration I used the BasedOnStyle:  Google, but it was just to initialize, we can discuss here which style base is better or just create a custom one. There is also a clang-format config detector that analyses the code and create the configurations but it is a windows-based software and I'm not able to try it now. 

