### PR TITLE
We should not error on forbidden characters

### DIFF
--- a/include/ada/idna/to_ascii.h
+++ b/include/ada/idna/to_ascii.h
@@ -18,8 +18,9 @@ namespace ada::idna {
 // This function may accept or even produce invalid domains.
 std::string to_ascii(std::string_view ut8_string);
 
-// Returns true if the string contains a forbidden code point according to the WHATGL URL
-// specification: https://url.spec.whatwg.org/#forbidden-domain-code-point
+// Returns true if the string contains a forbidden code point according to the
+// WHATGL URL specification:
+// https://url.spec.whatwg.org/#forbidden-domain-code-point
 bool contains_forbidden_domain_code_point(std::string_view ascii_string);
 
 bool constexpr begins_with(std::u32string_view view,
@@ -28,7 +29,6 @@ bool constexpr begins_with(std::string_view view, std::string_view prefix);
 
 bool constexpr is_ascii(std::u32string_view view);
 bool constexpr is_ascii(std::string_view view);
-
 
 }  // namespace ada::idna
 

--- a/include/ada/idna/to_ascii.h
+++ b/include/ada/idna/to_ascii.h
@@ -11,8 +11,16 @@ namespace ada::idna {
 // decoding: percent decoding should be done prior to calling this function. We
 // do not remove tabs and spaces, they should have been removed prior to calling
 // this function. We also do not trim control characters. We also assume that
-// the input is not empty. We return "" on error. For now.
+// the input is not empty. We return "" on error.
+//
+// Example: "www.öbb.at" -> "www.xn--bb-eka.at"
+//
+// This function may accept or even produce invalid domains.
 std::string to_ascii(std::string_view ut8_string);
+
+// Returns true if the string contains a forbidden code point according to the WHATGL URL
+// specification: https://url.spec.whatwg.org/#forbidden-domain-code-point
+bool contains_forbidden_domain_code_point(std::string_view ascii_string);
 
 bool constexpr begins_with(std::u32string_view view,
                            std::u32string_view prefix);
@@ -21,7 +29,6 @@ bool constexpr begins_with(std::string_view view, std::string_view prefix);
 bool constexpr is_ascii(std::u32string_view view);
 bool constexpr is_ascii(std::string_view view);
 
-std::string from_ascii_to_ascii(std::string_view ut8_string);
 
 }  // namespace ada::idna
 

--- a/src/to_ascii.cpp
+++ b/src/to_ascii.cpp
@@ -59,18 +59,17 @@ constexpr static uint8_t is_forbidden_domain_code_point_table[] = {
 
 static_assert(sizeof(is_forbidden_domain_code_point_table) == 256);
 
-inline constexpr bool is_forbidden_domain_code_point(const char c) noexcept {
+inline bool is_forbidden_domain_code_point(const char c) noexcept {
   return is_forbidden_domain_code_point_table[uint8_t(c)];
 }
 
-// We return "" on error. For now.
-std::string from_ascii_to_ascii(std::string_view ut8_string) {
-  static const std::string error = "";
-  if (std::any_of(ut8_string.begin(), ut8_string.end(),
-                  is_forbidden_domain_code_point)) {
-    return error;
-  }
+bool contains_forbidden_domain_code_point(std::string_view view) {
+  return (std::any_of(view.begin(), view.end(), is_forbidden_domain_code_point));
+}
 
+// We return "" on error.
+static std::string from_ascii_to_ascii(std::string_view ut8_string) {
+  static const std::string error = "";
   // copy and map
   // we could be more efficient by avoiding the copy when unnecessary.
   std::string mapped_string = std::string(ut8_string);
@@ -124,7 +123,7 @@ std::string from_ascii_to_ascii(std::string_view ut8_string) {
   return out;
 }
 
-// We return "" on error. For now.
+// We return "" on error.
 std::string to_ascii(std::string_view ut8_string) {
   if (is_ascii(ut8_string)) {
     return from_ascii_to_ascii(ut8_string);
@@ -211,11 +210,6 @@ std::string to_ascii(std::string_view ut8_string) {
       out.push_back('.');
     }
   }
-
-  if (std::any_of(out.begin(), out.end(), is_forbidden_domain_code_point)) {
-    return error;
-  }
-
   return out;
 }
 }  // namespace ada::idna

--- a/src/to_ascii.cpp
+++ b/src/to_ascii.cpp
@@ -64,7 +64,8 @@ inline bool is_forbidden_domain_code_point(const char c) noexcept {
 }
 
 bool contains_forbidden_domain_code_point(std::string_view view) {
-  return (std::any_of(view.begin(), view.end(), is_forbidden_domain_code_point));
+  return (
+      std::any_of(view.begin(), view.end(), is_forbidden_domain_code_point));
 }
 
 // We return "" on error.

--- a/tests/wpt_tests.cpp
+++ b/tests/wpt_tests.cpp
@@ -48,7 +48,7 @@ bool idna_test_v2_to_ascii(std::string_view filename) {
 
     std::string_view input = object["input"].get_string();
     std::string output = ada::idna::to_ascii(input);
-    if(ada::idna::contains_forbidden_domain_code_point(output)) {
+    if (ada::idna::contains_forbidden_domain_code_point(output)) {
       output = "";
     }
     auto expected_output = object["output"];

--- a/tests/wpt_tests.cpp
+++ b/tests/wpt_tests.cpp
@@ -48,6 +48,9 @@ bool idna_test_v2_to_ascii(std::string_view filename) {
 
     std::string_view input = object["input"].get_string();
     std::string output = ada::idna::to_ascii(input);
+    if(ada::idna::contains_forbidden_domain_code_point(output)) {
+      output = "";
+    }
     auto expected_output = object["output"];
 
     if (expected_output.is_null() && output.size()) {


### PR DESCRIPTION
We mistakenly triggered an error when forbidden characters were found as part of to_ascii, but that's a separate check.