### PR TITLE
fix -Wunreachable-code-break warning

### DIFF
--- a/src/mapping.cpp
+++ b/src/mapping.cpp
@@ -111,7 +111,6 @@ std::u32string map(std::u32string_view input) {
         break;
       case 2:
         return error;  // disallowed
-        break;
 
       // case 3 :
       default:


### PR DESCRIPTION
Fix a small `-Wunreachable-code-break` warning.

I found this a few steps downstream in Electron while working on Electron's Node.js roll, since Electron builds node with `-Werror,-Wunreachable-code-break` and Node.js uses ada :smile_cat: 

Related: https://github.com/ada-url/ada/pull/464