### PR TITLE
std::equal is not necessarily constexpr in C++17 (only C++20)

### DIFF
--- a/benchmarks/performancecounters/apple_arm_events.h
+++ b/benchmarks/performancecounters/apple_arm_events.h
@@ -615,9 +615,7 @@ typedef struct {
 
 #define lib_nelems(x) (sizeof(x) / sizeof((x)[0]))
 #define lib_symbol_def(name) \
-  {                          \
-#name, (void **)&name    \
-  }
+  { #name, (void **)&name }
 
 static const lib_symbol lib_symbols_kperf[] = {
     lib_symbol_def(kpc_pmu_version),

--- a/include/ada/idna/to_ascii.h
+++ b/include/ada/idna/to_ascii.h
@@ -22,8 +22,7 @@ std::string to_ascii(std::string_view ut8_string);
 // https://url.spec.whatwg.org/#forbidden-domain-code-point
 bool contains_forbidden_domain_code_point(std::string_view ascii_string);
 
-bool begins_with(std::u32string_view view,
-                           std::u32string_view prefix);
+bool begins_with(std::u32string_view view, std::u32string_view prefix);
 bool begins_with(std::string_view view, std::string_view prefix);
 
 bool constexpr is_ascii(std::u32string_view view);

--- a/include/ada/idna/to_ascii.h
+++ b/include/ada/idna/to_ascii.h
@@ -22,9 +22,9 @@ std::string to_ascii(std::string_view ut8_string);
 // https://url.spec.whatwg.org/#forbidden-domain-code-point
 bool contains_forbidden_domain_code_point(std::string_view ascii_string);
 
-bool constexpr begins_with(std::u32string_view view,
+bool begins_with(std::u32string_view view,
                            std::u32string_view prefix);
-bool constexpr begins_with(std::string_view view, std::string_view prefix);
+bool begins_with(std::string_view view, std::string_view prefix);
 
 bool constexpr is_ascii(std::u32string_view view);
 bool constexpr is_ascii(std::string_view view);

--- a/src/to_ascii.cpp
+++ b/src/to_ascii.cpp
@@ -11,8 +11,7 @@
 
 namespace ada::idna {
 
-bool begins_with(std::u32string_view view,
-                           std::u32string_view prefix) {
+bool begins_with(std::u32string_view view, std::u32string_view prefix) {
   if (view.size() < prefix.size()) {
     return false;
   }

--- a/src/to_ascii.cpp
+++ b/src/to_ascii.cpp
@@ -11,18 +11,20 @@
 
 namespace ada::idna {
 
-bool constexpr begins_with(std::u32string_view view,
+bool begins_with(std::u32string_view view,
                            std::u32string_view prefix) {
   if (view.size() < prefix.size()) {
     return false;
   }
+  // constexpr as of C++20
   return std::equal(prefix.begin(), prefix.end(), view.begin());
 }
 
-bool constexpr begins_with(std::string_view view, std::string_view prefix) {
+bool begins_with(std::string_view view, std::string_view prefix) {
   if (view.size() < prefix.size()) {
     return false;
   }
+  // constexpr as of C++20
   return std::equal(prefix.begin(), prefix.end(), view.begin());
 }
 


### PR DESCRIPTION
std::equal is not necessarily constexpr in C++17 (only C++20) which means that PR https://github.com/ada-url/idna/pull/35 broke idna technically.

See https://en.cppreference.com/w/cpp/algorithm/equal

This PR keeps std::equal, but removes the constexpr qualifiers on begins_with