### PR TITLE
Add cmake install steps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,3 +42,14 @@ else()
 endif(BUILD_TESTING)
 
 add_subdirectory(singleheader)
+
+
+install(
+    FILES include/idna.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(
+    DIRECTORY include/ada
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,3 +37,10 @@ endif()
 if(ADA_SANITIZE_UNDEFINED)
   target_compile_options(ada-idna INTERFACE -fsanitize=undefined -fno-sanitize-recover=all)
 endif()
+
+install(
+    TARGETS ada-idna
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)


### PR DESCRIPTION
Hello!

Conan is packaging your project here: https://github.com/conan-io/conan-center-index/pull/22891 to be distributed as a public package. As we using CMake to execute most of step, we found the install step missing.

This PR adds a new configuration to install headers and libraries when executing `cmake --build build --target install`:


```
$ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/tmp/install 
...   
$ cmake --build build --target install                                                                                                                                                                                                     10:28:18
[ 11%] Built target ada-idna
[ 22%] Built target punycode_tests
[ 33%] Built target to_ascii_tests
[ 44%] Built target mapping_tests
[ 55%] Built target to_unicode_tests
[ 66%] Built target simdjson
[ 77%] Built target wpt_tests
[ 83%] Built target singleheader-files
[100%] Built target demo
Install the project...
-- Install configuration: "Debug"
-- Installing: /tmp/install/lib/libada-idna.a
-- Installing: /tmp/install/include/idna.h
-- Installing: /tmp/install/include/ada
-- Installing: /tmp/install/include/ada/idna
-- Installing: /tmp/install/include/ada/idna/normalization.h
-- Installing: /tmp/install/include/ada/idna/mapping.h
-- Installing: /tmp/install/include/ada/idna/punycode.h
-- Installing: /tmp/install/include/ada/idna/validity.h
-- Installing: /tmp/install/include/ada/idna/to_ascii.h
-- Installing: /tmp/install/include/ada/idna/unicode_transcoding.h
-- Installing: /tmp/install/include/ada/idna/to_unicode.h
```