### PR TITLE
adds a test for issue 47

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -20,8 +20,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v1
       - name: Install extra dependencies
-        if: ${{ matrix.config.arch != '' }}
-        shell: 'sh'
         run: |
           sudo apt update && sudo apt install -y binfmt-support
       - name: Install latest Alpine Linux for ${{ matrix.arch }}

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -19,7 +19,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
-
+      - name: Install extra dependencies
+        if: ${{ matrix.config.arch != '' }}
+        shell: 'sh'
+        run: |
+          sudo apt update && sudo apt install -y binfmt-support
       - name: Install latest Alpine Linux for ${{ matrix.arch }}
         uses: jirutka/setup-alpine@v1
         with:

--- a/tests/to_ascii_tests.cpp
+++ b/tests/to_ascii_tests.cpp
@@ -55,6 +55,9 @@ bool test(std::string ut8_string, std::string puny_string) {
 }
 
 bool special_cases() {
+  if (!ada::idna::to_ascii("\xf0\xaf\xa1\xa8").empty()) {
+    return false;
+  }
   // We would prefer "\u1E9E" but Visual Studio complains.
   if (ada::idna::to_ascii("\xe1\xba\x9e") != "xn--zca") {
     return false;


### PR DESCRIPTION
@anonrig reports that the character U2f868 (\xf0\xaf\xa1\xa8 in UTF-8) should fail, but does not. Let us check. We can add the following check:

```C++
  if (!ada::idna::to_ascii("\xf0\xaf\xa1\xa8").empty()) {
     return false; // error
   }
```

https://github.com/ada-url/idna/issues/47



