### PR TITLE
fix shadow variable warnings

### DIFF
--- a/src/identifier.cpp
+++ b/src/identifier.cpp
@@ -33,16 +33,13 @@ bool valid_name_code_point(char32_t code_point, bool first) {
   if (first) {
     auto iter = std::lower_bound(
         std::begin(ada::idna::id_start), std::end(ada::idna::id_start),
-        code_point, [](const uint32_t* range, uint32_t code_point) {
-          return range[1] < code_point;
-        });
+        code_point,
+        [](const uint32_t* range, uint32_t cp) { return range[1] < cp; });
     return iter != std::end(id_start) && code_point >= (*iter)[0];
   } else {
     auto iter = std::lower_bound(
         std::begin(id_continue), std::end(id_continue), code_point,
-        [](const uint32_t* range, uint32_t code_point) {
-          return range[1] < code_point;
-        });
+        [](const uint32_t* range, uint32_t cp) { return range[1] < cp; });
     return iter != std::end(id_start) && code_point >= (*iter)[0];
   }
 }


### PR DESCRIPTION
code_point variable name was shadowing the upper scope definition.