### PR TITLE
Fixing leading surrogate in punycode_encode

### DIFF
--- a/src/punycode.cpp
+++ b/src/punycode.cpp
@@ -174,7 +174,7 @@ bool utf32_to_punycode(std::u32string_view input, std::string &out) {
       ++h;
       out.push_back(char(c));
     }
-    if (c > 0x10ffff || (c >= 0xd880 && c < 0xe000)) {
+    if (c > 0x10ffff || (c >= 0xd800 && c < 0xe000)) {
       return false;
     }
   }


### PR DESCRIPTION
UTF-16's Leading surrogate is `0xD800` not `0xD880`; though spec-wise, you wouldn't need to check these even (only if you don't cast char32_t to uint32_t which you do).

The reason why this wasn't breaking anything before was that invalid surrogate code points would probably been reported way before the flow would reach here.

Anyway, I saw, and here's a PR for it.