### PR TITLE
incomplete IDNA Bidi validation allowing invalid LTR labels with disallowed trailing code points

### DIFF
--- a/src/validity.cpp
+++ b/src/validity.cpp
@@ -1275,18 +1275,18 @@ bool is_label_valid(const std::u32string_view label) {
 
       // In an LTR label, only characters with the Bidi properties L, EN,
       // ES, CS, ET, ON, BN, or NSM are allowed.
-      for (size_t i = 0; i < last_non_nsm_char; i++) {
+      for (size_t i = 0; i <= last_non_nsm_char; i++) {
         const direction d = find_direction(label[i]);
         if (!(d == direction::L || d == direction::EN || d == direction::ES ||
               d == direction::CS || d == direction::ET || d == direction::ON ||
               d == direction::BN || d == direction::NSM)) {
           return false;
         }
+      }
 
-        if ((i == last_non_nsm_char) &&
-            !(d == direction::L || d == direction::EN)) {
-          return false;
-        }
+      const direction last_dir = find_direction(label[last_non_nsm_char]);
+      if (!(last_dir == direction::L || last_dir == direction::EN)) {
+        return false;
       }
 
       return true;

--- a/tests/to_ascii_tests.cpp
+++ b/tests/to_ascii_tests.cpp
@@ -154,3 +154,22 @@ TEST(to_ascii_tests, mixed_label_xn_prefix_regression) {
   std::string second = ada::idna::to_ascii(first);
   ASSERT_EQ(first, second) << "to_ascii must be idempotent";
 }
+
+TEST(to_ascii_tests, bidi_regression) {
+  // LTR label ending in RTL/AL/AN should fail (Rule 6)
+  EXPECT_TRUE(ada::idna::to_ascii("a\u05D0").empty()) << "LTR + RTL should fail";
+  EXPECT_TRUE(ada::idna::to_ascii("a\u0627").empty()) << "LTR + AL should fail";
+  EXPECT_TRUE(ada::idna::to_ascii("a\u0661").empty()) << "LTR + AN should fail";
+
+  // RTL + trailing NSM
+  EXPECT_TRUE(ada::idna::to_ascii("a\u05D0\u0301").empty()) << "RTL + trailing NSM should fail";
+
+  // NSM before RTL
+  EXPECT_TRUE(ada::idna::to_ascii("a\u0301\u05D0").empty()) << "NSM before RTL should fail";
+
+  // multiple RTL
+  EXPECT_TRUE(ada::idna::to_ascii("a\u05D0\u05D1").empty()) << "multiple RTL should fail";
+
+  // multi-label
+  EXPECT_TRUE(ada::idna::to_ascii("a\u05D0.b").empty()) << "multi-label should fail";
+}


### PR DESCRIPTION
## Summary
Fix incomplete IDNA Bidi validation for LTR labels where the last non-NSM code point was not validated.

## Root Cause
The loop stopped before `last_non_nsm_char`, skipping validation of the final non-NSM character and leaving Rule 6 unenforced.

## Fix
- Include `last_non_nsm_char` in validation
- Explicitly enforce final non-NSM must be `L` or `EN`

## Tests
Added regression cases for:
- LTR ending with RTL / AL / AN
- NSM interactions
- Multiple RTL and multi-label cases

All new tests fail before the fix and pass after it.

## Scope
Limited to `src/validity.cpp` and `tests/to_ascii_tests.cpp` with no unrelated changes.