### PR TITLE
harden to_unicode post-decode label validation

### DIFF
--- a/src/to_unicode.cpp
+++ b/src/to_unicode.cpp
@@ -3,8 +3,12 @@
 #include <algorithm>
 #include <string>
 
+#include "ada/idna/mapping.h"
+#include "ada/idna/normalization.h"
 #include "ada/idna/punycode.h"
+#include "ada/idna/to_ascii.h"
 #include "ada/idna/unicode_transcoding.h"
+#include "ada/idna/validity.h"
 #include "idna.h"
 
 #ifdef ADA_USE_SIMDUTF
@@ -18,6 +22,7 @@ std::string to_unicode(std::string_view input) {
 
   size_t label_start = 0;
   std::u32string tmp_buffer;
+  std::u32string post_map;
   while (label_start < input.size()) {
     size_t loc_dot = input.find('.', label_start);
     bool is_last_label = (loc_dot == std::string_view::npos);
@@ -29,21 +34,47 @@ std::string to_unicode(std::string_view input) {
       label_view.remove_prefix(4);
       tmp_buffer.clear();
       if (ada::idna::punycode_to_utf32(label_view, tmp_buffer)) {
+        // Per UTS #46, the decoded label must be re-validated. Reject decodings
+        // that are pure ASCII (xn-- encoding of an ASCII-only label), or whose
+        // mapping/normalization is not stable, or that fail label validity.
+        bool accept_decoded = true;
+        if (ada::idna::is_ascii(tmp_buffer)) {
+          accept_decoded = false;
+        } else {
+          post_map.clear();
+          if (!ada::idna::map(tmp_buffer, post_map) || post_map != tmp_buffer) {
+            accept_decoded = false;
+          } else {
+            ada::idna::normalize(post_map);
+            if (post_map != tmp_buffer || post_map.empty() ||
+                !ada::idna::is_label_valid(post_map)) {
+              accept_decoded = false;
+            }
+          }
+        }
+
+        if (accept_decoded) {
 #ifdef ADA_USE_SIMDUTF
-        auto utf8_size = simdutf::utf8_length_from_utf32(tmp_buffer.data(),
-                                                         tmp_buffer.size());
-        size_t old_size = output.size();
-        output.resize(old_size + utf8_size);
-        simdutf::convert_utf32_to_utf8(tmp_buffer.data(), tmp_buffer.size(),
-                                       output.data() + old_size);
-#else
-        auto utf8_size = ada::idna::utf8_length_from_utf32(tmp_buffer.data(),
+          auto utf8_size = simdutf::utf8_length_from_utf32(tmp_buffer.data(),
                                                            tmp_buffer.size());
-        size_t old_size = output.size();
-        output.resize(old_size + utf8_size);
-        ada::idna::utf32_to_utf8(tmp_buffer.data(), tmp_buffer.size(),
-                                 output.data() + old_size);
+          size_t old_size = output.size();
+          output.resize(old_size + utf8_size);
+          simdutf::convert_utf32_to_utf8(tmp_buffer.data(), tmp_buffer.size(),
+                                         output.data() + old_size);
+#else
+          auto utf8_size = ada::idna::utf8_length_from_utf32(tmp_buffer.data(),
+                                                             tmp_buffer.size());
+          size_t old_size = output.size();
+          output.resize(old_size + utf8_size);
+          ada::idna::utf32_to_utf8(tmp_buffer.data(), tmp_buffer.size(),
+                                   output.data() + old_size);
 #endif
+        } else {
+          // ToUnicode never fails. If any step fails, return the original
+          // input sequence for the label.
+          output.append(
+              std::string_view(input.data() + label_start, label_size));
+        }
       } else {
         // ToUnicode never fails.  If any step fails, then the original input
         // sequence is returned immediately in that step.

--- a/tests/to_unicode_tests.cpp
+++ b/tests/to_unicode_tests.cpp
@@ -43,6 +43,21 @@ class IdnaToUnicodeTest : public ::testing::Test {
   }
 };
 
+// Labels whose punycode decodes to pure ASCII (e.g. "xn--abc-" -> "abc") must
+// NOT be emitted as the decoded form — they should stay in their original
+// xn-- form. Per UTS #46, the decoded label must round-trip through mapping,
+// normalization, and validity; an ASCII-only decoding implies a malformed
+// xn-- label.
+TEST(IdnaToUnicodeValidation, PunycodeDecodingToAsciiIsRejected) {
+  EXPECT_EQ(ada::idna::to_unicode("xn--abc-"), "xn--abc-");
+}
+
+// A genuine non-ASCII punycode label should still decode normally.
+TEST(IdnaToUnicodeValidation, ValidPunycodeStillDecodes) {
+  // xn--maana-pta -> mañana
+  EXPECT_EQ(ada::idna::to_unicode("xn--maana-pta"), "mañana");
+}
+
 // Test for Unicode conversions from file
 TEST_F(IdnaToUnicodeTest, AlternatingFileConversions) {
   std::string filename = GetUnicodeFilename();


### PR DESCRIPTION
Harden `to_unicode()` by revalidating labels after punycode decoding, per UTS #46 requirements.

Previously, decoded `xn--` labels were emitted directly after decoding without verifying that the resulting Unicode label remained valid and canonical. This could allow malformed or non-canonical ACE labels to be rendered as trusted Unicode.

This patch adds post-decode validation and falls back to the original ACE label when the decoded result is invalid.

## Validation checks added

After decoding, the label is rejected if:

* the decoded output is pure ASCII
* Unicode mapping is unstable (`map(decoded) != decoded`)
* NFC normalization is unstable (`NFC(decoded) != decoded`)
* the label fails `is_label_valid`
* the decoded label is empty

## Additional changes

* Ports the validation logic from ada-url/ada#1138 into the upstream ada-idna implementation
* Preserves the non-simdutf `utf32_to_utf8` emission branch that was unintentionally dropped in the downstream patch
