### PR TITLE
we want our code to be only ASCII for maximal portability

### DIFF
--- a/scripts/idna_table.py
+++ b/scripts/idna_table.py
@@ -123,7 +123,7 @@ def build_flat_and_mappings(entries, low_range_end):
     Returns (flat, utf8_table, seq_to_idx) where
       flat[cp] = SENTINEL_VALID | SENTINEL_DISALLOWED | utf8_byte_offset
       utf8_table = bytearray of null-terminated UTF-8 mapping strings
-      seq_to_idx = dict mapping tuple of codepoints → byte offset in utf8_table
+      seq_to_idx = dict mapping tuple of codepoints -> byte offset in utf8_table
     """
     flat = [SENTINEL_DISALLOWED] * low_range_end
 
@@ -147,7 +147,7 @@ def build_flat_and_mappings(entries, low_range_end):
         hi = min(cp_end + 1, low_range_end)
         if lo >= hi:
             continue
-        if code == 0:   # ignored → empty mapping
+        if code == 0:   # ignored -> empty mapping
             val = IGNORED_IDX
         elif code == 1: # valid
             val = SENTINEL_VALID
@@ -165,8 +165,8 @@ def build_two_level(flat):
     """
     Returns (stage1, mixed_data, bool_words) where
       stage1[i] = index for block i
-        bit 15 set  → bool block: lower 15 bits = bool_block_idx
-        bit 15 clear → mixed block: value = base offset into mixed_data[]
+        bit 15 set  -> bool block: lower 15 bits = bool_block_idx
+        bit 15 clear -> mixed block: value = base offset into mixed_data[]
       mixed_data = flat uint16_t array (all mixed blocks concatenated)
       bool_words = list of uint64_t bitwords; bit k=1 ↔ code point is VALID
     """
@@ -175,8 +175,8 @@ def build_two_level(flat):
     stage1      = []
     mixed_data  = []
     bool_words  = []
-    mixed_map   = {}   # tuple(block) → base offset in mixed_data
-    bool_map    = {}   # int (bitword) → index in bool_words
+    mixed_map   = {}   # tuple(block) -> base offset in mixed_data
+    bool_map    = {}   # int (bitword) -> index in bool_words
 
     for bi in range(n_blocks):
         start = bi * block_size
@@ -328,8 +328,8 @@ def print_idna():
 
     # ── stage1 ─────────────────────────────────────────────────────────────────
     print(f"// idna_stage1[cp >> {BLOCK_BITS}]: one entry per {BLOCK_SIZE}-code-point block.")
-    print(f"// Bit 15 set  → lower 15 bits = index into idna_bool_blocks[].")
-    print(f"// Bit 15 clear → value = base offset into idna_stage2[] for this block.")
+    print(f"// Bit 15 set  -> lower 15 bits = index into idna_bool_blocks[].")
+    print(f"// Bit 15 clear -> value = base offset into idna_stage2[] for this block.")
     print(emit_array_uint16(f"idna_stage1", stage1))
     print()
 
@@ -341,7 +341,7 @@ def print_idna():
 
     # ── boolean blocks ──────────────────────────────────────────────────────────
     print(f"// idna_bool_blocks[]: one uint64_t per boolean block.")
-    print(f"// Bit k (0 = LSB) = 1 → (block_start + k) is VALID; 0 → DISALLOWED.")
+    print(f"// Bit k (0 = LSB) = 1 -> (block_start + k) is VALID; 0 -> DISALLOWED.")
     print(emit_array_uint64(f"idna_bool_blocks", bool_words))
     print()
 

--- a/src/mapping.cpp
+++ b/src/mapping.cpp
@@ -9,20 +9,20 @@
 
 namespace ada::idna {
 
-// ─── O(1) two-level table lookup ─────────────────────────────────────────────
+// --- O(1) two-level table lookup ---------------------------------------------
 //
 // Returns one of:
-//   IDNA_VALID      – keep code point in output unchanged
-//   IDNA_DISALLOWED – code point is not allowed (map() returns error)
-//   IDNA_IGNORED    – code point is ignored (index 0 = empty UTF-8 entry)
-//   other           – byte offset into idna_utf8_mappings[] (null-terminated)
+//   IDNA_VALID      - keep code point in output unchanged
+//   IDNA_DISALLOWED - code point is not allowed (map() returns error)
+//   IDNA_IGNORED    - code point is ignored (index 0 = empty UTF-8 entry)
+//   other           - byte offset into idna_utf8_mappings[] (null-terminated)
 //
 // The two-level table covers [0, IDNA_LOW_RANGE_END).  All constants
 // (LOW_RANGE_END, HIGH_IGNORED_*) are generated from the IDNA table itself;
 // no Unicode version-specific values are hardcoded here.
 //
 static uint16_t idna_lookup(uint32_t cp) noexcept {
-  // ── Two-level table covers the full active code-point range ───────────────
+  // -- Two-level table covers the full active code-point range ---------------
   if (cp < IDNA_LOW_RANGE_END) {
     uint16_t ref = idna_stage1[cp >> IDNA_BLOCK_BITS];
     if (ref & IDNA_BOOL_FLAG) {
@@ -36,7 +36,7 @@ static uint16_t idna_lookup(uint32_t cp) noexcept {
     return idna_stage2[ref + (cp & IDNA_BLOCK_MASK)];
   }
 
-  // ── Variation selectors supplement (U+E0100–U+E01EF): all ignored ─────────
+  // -- Variation selectors supplement (U+E0100-U+E01EF): all ignored ---------
   // Everything else above IDNA_LOW_RANGE_END is disallowed.
   if (cp >= IDNA_HIGH_IGNORED_START && cp < IDNA_HIGH_IGNORED_END) {
     return IDNA_IGNORED;
@@ -45,7 +45,7 @@ static uint16_t idna_lookup(uint32_t cp) noexcept {
   return IDNA_DISALLOWED;
 }
 
-// ─── Decode one UTF-8 code point ─────────────────────────────────────────────
+// --- Decode one UTF-8 code point ---------------------------------------------
 // Advances *ptr past the bytes consumed.  The mapping table is trusted to be
 // well-formed UTF-8, so no validity checking is performed.
 static char32_t utf8_next(const uint8_t*& ptr) noexcept {
@@ -70,8 +70,8 @@ static char32_t utf8_next(const uint8_t*& ptr) noexcept {
   return static_cast<char32_t>(cp);
 }
 
-// ─── ASCII fast path
-// ──────────────────────────────────────────────────────────
+// --- ASCII fast path
+// ----------------------------------------------------------
 void ascii_map(char* input, size_t length) {
   auto broadcast = [](uint8_t v) -> uint64_t {
     return 0x101010101010101ull * v;
@@ -97,8 +97,8 @@ void ascii_map(char* input, size_t length) {
   }
 }
 
-// ─── IDNA map
-// ───────────────────────────────────────────────────────────────── Maps each
+// --- IDNA map
+// ----------------------------------------------------------------- Maps each
 // code point according to IDNA processing. Returns an empty string on error
 // (disallowed code point encountered).
 bool map(std::u32string_view input, std::u32string& out) {

--- a/src/mapping_tables.cpp
+++ b/src/mapping_tables.cpp
@@ -39,8 +39,8 @@ constexpr uint32_t IDNA_HIGH_IGNORED_START = 0x000E0100;
 constexpr uint32_t IDNA_HIGH_IGNORED_END   = 0x000E01F0;  // exclusive
 
 // idna_stage1[cp >> 6]: one entry per 64-code-point block.
-// Bit 15 set  → lower 15 bits = index into idna_bool_blocks[].
-// Bit 15 clear → value = base offset into idna_stage2[] for this block.
+// Bit 15 set  -> lower 15 bits = index into idna_bool_blocks[].
+// Bit 15 clear -> value = base offset into idna_stage2[] for this block.
 const uint16_t idna_stage1[3282] = {
 	0x8000, 0x0000, 0x0040, 0x0080, 0x00C0, 0x0100, 0x0140, 0x0180, 0x01C0, 0x0200, 0x0240, 0x0280,
 	0x8000, 0x02C0, 0x0300, 0x0340, 0x0380, 0x03C0, 0x0400, 0x0440, 0x0480, 0x04C0, 0x0500, 0x8001,
@@ -1279,7 +1279,7 @@ const uint16_t idna_stage2[11456] = {
 };
 
 // idna_bool_blocks[]: one uint64_t per boolean block.
-// Bit k (0 = LSB) = 1 → (block_start + k) is VALID; 0 → DISALLOWED.
+// Bit k (0 = LSB) = 1 -> (block_start + k) is VALID; 0 -> DISALLOWED.
 const uint64_t idna_bool_blocks[225] = {
 	0xFFFFFFFFFFFFFFFFULL, 0x001F87FFFFFF00FFULL, 0xFFFFFFFFEFFFFFC0ULL, 0xFFFFFFFFDFFFFFFFULL,
 	0xFFFFFFFFFFFF3FFFULL, 0xFFFFFFFFFFFFE7FFULL, 0x0003FFFFFFFFFFFFULL, 0xE7FFFFFFFFFFFFFFULL,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,7 +66,7 @@ if(FIND AND FILE AND GREP)
   add_test(
       NAME just_ascii
       COMMAND sh -c "\
-${FIND} include src windows tools singleheader tests examples benchmark \
+${FIND} include src  singleheader tests \
 -path benchmark/checkperf-reference -prune -name '*.h' -o -name '*.cpp' \
 -type f -exec ${FILE} '{}' \; | ${GREP} -qv ASCII || exit 0  && exit 1"
       WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,7 +66,7 @@ if(FIND AND FILE AND GREP)
   add_test(
       NAME just_ascii
       COMMAND sh -c "\
-${FIND} include src  singleheader tests \
+${FIND} include src  \
 -path benchmark/checkperf-reference -prune -name '*.h' -o -name '*.cpp' \
 -type f -exec ${FILE} '{}' \; | ${GREP} -qv ASCII || exit 0  && exit 1"
       WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,3 +58,17 @@ else()
   endif()
 
 endif()
+
+find_program(FIND find)
+find_program(FILE file)
+find_program(GREP grep)
+if(FIND AND FILE AND GREP)
+  add_test(
+      NAME just_ascii
+      COMMAND sh -c "\
+${FIND} include src windows tools singleheader tests examples benchmark \
+-path benchmark/checkperf-reference -prune -name '*.h' -o -name '*.cpp' \
+-type f -exec ${FILE} '{}' \; | ${GREP} -qv ASCII || exit 0  && exit 1"
+      WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+  )
+endif()

--- a/tests/mapping_tests.cpp
+++ b/tests/mapping_tests.cpp
@@ -29,7 +29,7 @@ TEST(mapping_tests, ascii_digits_and_hyphen_valid) {
   EXPECT_EQ(ada::idna::map(U"-"), U"-");  // hyphen-minus
 }
 
-// ── Ignored code points → empty output ────────────────────────────────────
+// ── Ignored code points -> empty output ────────────────────────────────────
 TEST(mapping_tests, ignored_code_points) {
   // U+00AD SOFT HYPHEN
   EXPECT_EQ(ada::idna::map(U"\U000000AD"), U"");
@@ -45,7 +45,7 @@ TEST(mapping_tests, ignored_code_points) {
 
 // Ignored code points embedded in a valid string vanish.
 TEST(mapping_tests, ignored_embedded_in_valid) {
-  // "ab\u034Fcd" → "abcd"  (CGJ between valid chars)
+  // "ab\u034Fcd" -> "abcd"  (CGJ between valid chars)
   EXPECT_EQ(ada::idna::map(U"ab\U0000034Fcd"), U"abcd");
   // Soft-hyphen inside a word
   EXPECT_EQ(ada::idna::map(U"foo\U000000ADbar"), U"foobar");
@@ -61,7 +61,7 @@ TEST(mapping_tests, variation_selector_supplement_ignored) {
   EXPECT_EQ(ada::idna::map(U"\U000E01EF"), U"");
 }
 
-// ── Disallowed code points → empty string returned from map() ─────────────
+// ── Disallowed code points -> empty string returned from map() ─────────────
 // Note: U+007F (DEL) is actually VALID in IDNA (range 007B..007F valid NV8).
 // The first disallowed code point after ASCII printables is U+0080.
 TEST(mapping_tests, disallowed_returns_empty) {
@@ -85,42 +85,42 @@ TEST(mapping_tests, disallowed_returns_empty) {
 
 // ── Single-code-point mappings ─────────────────────────────────────────────
 TEST(mapping_tests, single_codepoint_mappings) {
-  // U+00AA FEMININE ORDINAL INDICATOR → 'a'
+  // U+00AA FEMININE ORDINAL INDICATOR -> 'a'
   EXPECT_EQ(ada::idna::map(U"\U000000AA"), U"a");
-  // U+00BA MASCULINE ORDINAL INDICATOR → 'o'
+  // U+00BA MASCULINE ORDINAL INDICATOR -> 'o'
   EXPECT_EQ(ada::idna::map(U"\U000000BA"), U"o");
-  // U+00B5 MICRO SIGN → U+03BC (Greek small mu)
+  // U+00B5 MICRO SIGN -> U+03BC (Greek small mu)
   EXPECT_EQ(ada::idna::map(U"\U000000B5"), U"\U000003BC");
-  // U+03A3 GREEK CAPITAL SIGMA → U+03C3
+  // U+03A3 GREEK CAPITAL SIGMA -> U+03C3
   EXPECT_EQ(ada::idna::map(U"\U000003A3"), U"\U000003C3");
-  // U+0410 CYRILLIC CAPITAL A → U+0430
+  // U+0410 CYRILLIC CAPITAL A -> U+0430
   EXPECT_EQ(ada::idna::map(U"\U00000410"), U"\U00000430");
-  // U+FF21 FULLWIDTH LATIN CAPITAL LETTER A → 'a'
+  // U+FF21 FULLWIDTH LATIN CAPITAL LETTER A -> 'a'
   EXPECT_EQ(ada::idna::map(U"\U0000FF21"), U"a");
-  // U+FF3A FULLWIDTH LATIN CAPITAL LETTER Z → 'z'
+  // U+FF3A FULLWIDTH LATIN CAPITAL LETTER Z -> 'z'
   EXPECT_EQ(ada::idna::map(U"\U0000FF3A"), U"z");
 }
 
 // ── Multi-code-point mappings ──────────────────────────────────────────────
 TEST(mapping_tests, multi_codepoint_mappings) {
-  // U+00B2 SUPERSCRIPT TWO → "2"
+  // U+00B2 SUPERSCRIPT TWO -> "2"
   EXPECT_EQ(ada::idna::map(U"\U000000B2"), U"2");
-  // U+00B3 SUPERSCRIPT THREE → "3"
+  // U+00B3 SUPERSCRIPT THREE -> "3"
   EXPECT_EQ(ada::idna::map(U"\U000000B3"), U"3");
-  // U+00BC VULGAR FRACTION ONE QUARTER → "1/4" (U+0031 U+2044 U+0034)
+  // U+00BC VULGAR FRACTION ONE QUARTER -> "1/4" (U+0031 U+2044 U+0034)
   EXPECT_EQ(ada::idna::map(U"\U000000BC"),
             (std::u32string{0x31, 0x2044, 0x34}));
-  // U+FB00 LATIN SMALL LIGATURE FF → "ff"
+  // U+FB00 LATIN SMALL LIGATURE FF -> "ff"
   EXPECT_EQ(ada::idna::map(U"\U0000FB00"), U"ff");
-  // U+FB01 LATIN SMALL LIGATURE FI → "fi"
+  // U+FB01 LATIN SMALL LIGATURE FI -> "fi"
   EXPECT_EQ(ada::idna::map(U"\U0000FB01"), U"fi");
-  // U+FB03 LATIN SMALL LIGATURE FFI → "ffi"
+  // U+FB03 LATIN SMALL LIGATURE FFI -> "ffi"
   EXPECT_EQ(ada::idna::map(U"\U0000FB03"), U"ffi");
-  // U+0132 LATIN CAPITAL LIGATURE IJ → "ij"
+  // U+0132 LATIN CAPITAL LIGATURE IJ -> "ij"
   EXPECT_EQ(ada::idna::map(U"\U00000132"), U"ij");
-  // U+01F1 LATIN CAPITAL LETTER DZ → "dz"
+  // U+01F1 LATIN CAPITAL LETTER DZ -> "dz"
   EXPECT_EQ(ada::idna::map(U"\U000001F1"), U"dz");
-  // U+1E9E LATIN CAPITAL LETTER SHARP S → U+00DF
+  // U+1E9E LATIN CAPITAL LETTER SHARP S -> U+00DF
   EXPECT_EQ(ada::idna::map(U"\U00001E9E"), U"\U000000DF");
 }
 
@@ -168,7 +168,7 @@ TEST(mapping_tests, mid_range_boundaries) {
 
 // ── High ignored range boundaries (0xE0100–0xE01EF) ───────────────────────
 TEST(mapping_tests, high_ignored_range_boundaries) {
-  // U+E00FF: just before the ignored range → disallowed
+  // U+E00FF: just before the ignored range -> disallowed
   EXPECT_TRUE(ada::idna::map(U"\U000E00FF").empty());
 
   // U+E0100: first in the ignored range
@@ -177,7 +177,7 @@ TEST(mapping_tests, high_ignored_range_boundaries) {
   // U+E01EF: last in the ignored range
   EXPECT_EQ(ada::idna::map(U"\U000E01EF"), U"");
 
-  // U+E01F0: just after the ignored range → disallowed
+  // U+E01F0: just after the ignored range -> disallowed
   EXPECT_TRUE(ada::idna::map(U"\U000E01F0").empty());
 }
 
@@ -196,17 +196,17 @@ TEST(mapping_tests, block_boundary_conditions) {
   // Block 2 starts at cp 128 (U+0080 first C1 control) – disallowed
   EXPECT_TRUE(ada::idna::map(std::u32string(1, char32_t(0x80))).empty());
 
-  // Block 3: cp 192 (U+00C0 'À') → mapped to 'à' (U+00E0)
+  // Block 3: cp 192 (U+00C0 'À') -> mapped to 'à' (U+00E0)
   EXPECT_EQ(ada::idna::map(U"\U000000C0"), U"\U000000E0");
-  // Block 3: cp 223 (U+00DF 'ß') → valid
+  // Block 3: cp 223 (U+00DF 'ß') -> valid
   EXPECT_EQ(ada::idna::map(U"\U000000DF"), U"\U000000DF");
-  // Block 4: cp 224 (U+00E0 'à') → valid
+  // Block 4: cp 224 (U+00E0 'à') -> valid
   EXPECT_EQ(ada::idna::map(U"\U000000E0"), U"\U000000E0");
 
-  // Block at 0x640 (cp 1600 = Arabic tatweel, U+0640) → valid
+  // Block at 0x640 (cp 1600 = Arabic tatweel, U+0640) -> valid
   EXPECT_EQ(ada::idna::map(U"\U00000640"), U"\U00000640");
 
-  // cp 0x3FC (1020 = U+03FC GREEK SMALL LETTER RHO WITH STROKE) → valid
+  // cp 0x3FC (1020 = U+03FC GREEK SMALL LETTER RHO WITH STROKE) -> valid
   EXPECT_EQ(ada::idna::map(U"\U000003FC"), U"\U000003FC");
 }
 
@@ -246,7 +246,7 @@ TEST(mapping_tests, string_disallowed_anywhere_fails) {
 }
 
 TEST(mapping_tests, string_multi_cp_mappings_in_context) {
-  // "ﬁle" (fi ligature + "le") → "file"
+  // "ﬁle" (fi ligature + "le") -> "file"
   EXPECT_EQ(ada::idna::map(U"\U0000FB01le"), U"file");
   // Mix of uppercase, ligature, and valid
   EXPECT_EQ(ada::idna::map(U"A\U0000FB00B"), U"affb");


### PR DESCRIPTION
The ada library checks that the code is pure ASCII.

We do this to avoid problems with systems such as a Microsoft editors that defaults on some other text formats (other than UTF-8).

