### PR TITLE
Let us modernize the code with std::span

### DIFF
--- a/src/identifier.cpp
+++ b/src/identifier.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <span>
 #include <string>
 
 #include "id_tables.cpp"
@@ -18,29 +19,34 @@ constexpr bool is_ascii_letter_or_digit(char32_t c) noexcept {
 
 bool valid_name_code_point(char32_t code_point, bool first) {
   // https://tc39.es/ecma262/#prod-IdentifierStart
-  // Fast paths:
-  if (first &&
-      (code_point == '$' || code_point == '_' || is_ascii_letter(code_point))) {
+
+  // Fast paths
+  if (first && (code_point == U'$' || code_point == U'_' ||
+                is_ascii_letter(code_point))) {
     return true;
   }
-  if (!first && (code_point == '$' || is_ascii_letter_or_digit(code_point))) {
+  if (!first && (code_point == U'$' || is_ascii_letter_or_digit(code_point))) {
     return true;
   }
-  // Slow path...
-  if (code_point == 0xffffffff) {
-    return false;  // minimal error handling
+
+  // Minimal error handling for invalid code point
+  if (code_point > 0x10FFFF) {
+    return false;
   }
-  if (first) {
-    auto iter = std::lower_bound(
-        std::begin(ada::idna::id_start), std::end(ada::idna::id_start),
-        code_point,
-        [](const uint32_t* range, uint32_t cp) { return range[1] < cp; });
-    return iter != std::end(id_start) && code_point >= (*iter)[0];
-  } else {
-    auto iter = std::lower_bound(
-        std::begin(id_continue), std::end(id_continue), code_point,
-        [](const uint32_t* range, uint32_t cp) { return range[1] < cp; });
-    return iter != std::end(id_start) && code_point >= (*iter)[0];
+  if (code_point >= 0xD800 && code_point <= 0xDFFF) {
+    return false;
   }
+
+  // Slow path: binary search through the appropriate Unicode range table.
+  // Each entry is a [low, high] inclusive range.
+  const std::span<const uint32_t[2]> ranges =
+      first ? std::span<const uint32_t[2]>{ada::idna::id_start}
+            : std::span<const uint32_t[2]>{ada::idna::id_continue};
+
+  const auto iter = std::ranges::lower_bound(
+      ranges, code_point, {},
+      [](const auto& range) { return range[1]; });  // project to range-high
+
+  return iter != ranges.end() && code_point >= (*iter)[0];
 }
 }  // namespace ada::idna

--- a/src/validity.cpp
+++ b/src/validity.cpp
@@ -766,19 +766,17 @@ static directions dir_table[] = {
 // CheckJoiners and CheckBidi are true for URL specification.
 
 inline static direction find_direction(uint32_t code_point) noexcept {
-  auto it = std::lower_bound(
-      std::begin(dir_table), std::end(dir_table), code_point,
-      [](const directions& d, uint32_t c) { return d.final_code < c; });
+  const auto it = std::ranges::lower_bound(
+      dir_table, code_point, {},
+      &directions::final_code);  // project to the upper bound of each range
 
-  // next check is almost surely in vain, but we use it for safety.
-  if (it == std::end(dir_table)) {
+  // Safety check - almost always false, but cheap.
+  if (it == std::ranges::end(dir_table)) {
     return direction::NONE;
   }
-  // We have that d.final_code >= c.
-  if (code_point >= it->start_code) {
-    return it->direct;
-  }
-  return direction::NONE;
+
+  // Invariant: it->final_code >= code_point. Confirm it's also in range.
+  return code_point >= it->start_code ? it->direct : direction::NONE;
 }
 
 inline static size_t find_last_not_of_nsm(
@@ -1116,8 +1114,7 @@ bool is_label_valid(const std::u32string_view label) {
       0xe01d9, 0xe01da, 0xe01db, 0xe01dc, 0xe01dd, 0xe01de, 0xe01df, 0xe01e0,
       0xe01e1, 0xe01e2, 0xe01e3, 0xe01e4, 0xe01e5, 0xe01e6, 0xe01e7, 0xe01e8,
       0xe01e9, 0xe01ea, 0xe01eb, 0xe01ec, 0xe01ed, 0xe01ee, 0xe01ef};
-  if (std::binary_search(std::begin(combining), std::end(combining),
-                         label.front())) {
+  if (std::ranges::binary_search(combining, label.front())) {
     return false;
   }
   // We verify this next step as part of the mapping:
@@ -1193,8 +1190,7 @@ bool is_label_valid(const std::u32string_view label) {
     uint32_t c = label[i];
     if (c == 0x200c) {
       if (i > 0) {
-        if (std::binary_search(std::begin(virama), std::end(virama),
-                               label[i - 1])) {
+        if (std::ranges::binary_search(virama, label[i - 1])) {
           return true;
         }
       }
@@ -1203,12 +1199,12 @@ bool is_label_valid(const std::u32string_view label) {
       }
       // we go backward looking for L or D
       auto is_l_or_d = [](uint32_t code) {
-        return std::binary_search(std::begin(L), std::end(L), code) ||
-               std::binary_search(std::begin(D), std::end(D), code);
+        return std::ranges::binary_search(L, code) ||
+               std::ranges::binary_search(D, code);
       };
       auto is_r_or_d = [](uint32_t code) {
-        return std::binary_search(std::begin(R), std::end(R), code) ||
-               std::binary_search(std::begin(D), std::end(D), code);
+        return std::ranges::binary_search(R, code) ||
+               std::ranges::binary_search(D, code);
       };
       std::u32string_view before = label.substr(0, i);
       std::u32string_view after = label.substr(i + 1);
@@ -1218,8 +1214,7 @@ bool is_label_valid(const std::u32string_view label) {
               after.end());
     } else if (c == 0x200d) {
       if (i > 0) {
-        if (std::binary_search(std::begin(virama), std::end(virama),
-                               label[i - 1])) {
+        if (std::ranges::binary_search(virama, label[i - 1])) {
           return true;
         }
       }

--- a/tests/identifier_tests.cpp
+++ b/tests/identifier_tests.cpp
@@ -1,7 +1,15 @@
 #include "gtest/gtest.h"
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
+#include <iterator>
+#include <random>
 
 #include "idna.h"
+
+// Pull in the raw Unicode range tables so the exhaustive test below can use
+// them as the ground truth against valid_name_code_point().
+#include "../src/id_tables.cpp"
 
 class IdnaTest : public testing::Test {
  protected:
@@ -38,4 +46,89 @@ TEST_F(IdnaTest, OtherPositionCodePoints) {
   VerifyCodePoint("À", false, true);
   VerifyCodePoint("0", false, true);
   VerifyCodePoint(" ", false, false);
+}
+
+// Disabled by default: exhaustive sweep over all 1.1M code points is slow.
+// Run explicitly with `--gtest_also_run_disabled_tests`.
+TEST_F(IdnaTest, DISABLED_ExhaustiveAgainstIdTables) {
+  // Walk the entire Unicode code-point space [0, 0x10FFFF] and confirm that
+  // valid_name_code_point() agrees with a direct scan of id_start /
+  // id_continue.
+  //
+  // The function adds two JS-identifier extensions on top of the Unicode
+  // ID_Start / ID_Continue properties (per
+  // https://tc39.es/ecma262/#prod-IdentifierStart):
+  //   - '$' and '_' are valid in IdentifierStart
+  //   - '$' is valid in IdentifierPart
+  // Surrogates (U+D800..U+DFFF) are rejected outright.
+  //
+  // The tables are sorted by range, so we walk them with rolling indices
+  // (si, ci) that only ever advance — O(N + table_size) total work.
+  constexpr std::size_t id_start_n = std::size(ada::idna::id_start);
+  constexpr std::size_t id_continue_n = std::size(ada::idna::id_continue);
+
+  std::size_t si = 0, ci = 0;
+  for (uint32_t cp = 0; cp <= 0x10FFFF; ++cp) {
+    while (si < id_start_n && ada::idna::id_start[si][1] < cp) ++si;
+    while (ci < id_continue_n && ada::idna::id_continue[ci][1] < cp) ++ci;
+
+    const bool is_surrogate = (cp >= 0xD800 && cp <= 0xDFFF);
+
+    const bool expected_first =
+        !is_surrogate &&
+        (cp == U'$' || cp == U'_' ||
+         (si < id_start_n && cp >= ada::idna::id_start[si][0]));
+
+    const bool expected_continue =
+        !is_surrogate && (cp == U'$' || (ci < id_continue_n &&
+                                         cp >= ada::idna::id_continue[ci][0]));
+
+    ASSERT_EQ(ada::idna::valid_name_code_point(static_cast<char32_t>(cp), true),
+              expected_first)
+        << "Mismatch at U+" << std::hex << cp << " (first=true)";
+    ASSERT_EQ(
+        ada::idna::valid_name_code_point(static_cast<char32_t>(cp), false),
+        expected_continue)
+        << "Mismatch at U+" << std::hex << cp << " (first=false)";
+  }
+}
+
+TEST_F(IdnaTest, SampledAgainstIdTables) {
+  // Same check as DISABLED_ExhaustiveAgainstIdTables, but samples roughly
+  // 1 in 100 code points using a fixed-seed RNG so the run is deterministic
+  // and fast enough for the default test suite. The rolling table indices
+  // still advance for every code point so they remain consistent at the
+  // sampled positions.
+  constexpr std::size_t id_start_n = std::size(ada::idna::id_start);
+  constexpr std::size_t id_continue_n = std::size(ada::idna::id_continue);
+
+  std::mt19937 rng(0xC0DE);
+  std::uniform_int_distribution<int> pick(0, 99);
+
+  std::size_t si = 0, ci = 0;
+  for (uint32_t cp = 0; cp <= 0x10FFFF; ++cp) {
+    while (si < id_start_n && ada::idna::id_start[si][1] < cp) ++si;
+    while (ci < id_continue_n && ada::idna::id_continue[ci][1] < cp) ++ci;
+
+    if (pick(rng) != 0) continue;
+
+    const bool is_surrogate = (cp >= 0xD800 && cp <= 0xDFFF);
+
+    const bool expected_first =
+        !is_surrogate &&
+        (cp == U'$' || cp == U'_' ||
+         (si < id_start_n && cp >= ada::idna::id_start[si][0]));
+
+    const bool expected_continue =
+        !is_surrogate && (cp == U'$' || (ci < id_continue_n &&
+                                         cp >= ada::idna::id_continue[ci][0]));
+
+    ASSERT_EQ(ada::idna::valid_name_code_point(static_cast<char32_t>(cp), true),
+              expected_first)
+        << "Mismatch at U+" << std::hex << cp << " (first=true)";
+    ASSERT_EQ(
+        ada::idna::valid_name_code_point(static_cast<char32_t>(cp), false),
+        expected_continue)
+        << "Mismatch at U+" << std::hex << cp << " (first=false)";
+  }
 }


### PR DESCRIPTION
The library still uses pre-C++20 constructs. In particular, we have a strange mix-up with the ugly `std::end()` that should no longer be used in C++.

Bug found by @metsw24-max




Fixes: https://github.com/ada-url/ada/pull/1146