### PR TITLE
test: port extensive Ada/WPT domain-to-ASCII carve-out coverage

### DIFF
--- a/tests/fixtures/toascii.json
+++ b/tests/fixtures/toascii.json
@@ -1,0 +1,378 @@
+[
+  "This contains assorted IDNA tests that IdnaTestV2 might not cover.",
+  "Feel free to deduplicate with a clear commit message.",
+  "",
+  "If the test only applies to the URL Standard's 'domain to ASCII', ",
+  "and not to TR46's ToASCII, then tag it with `urlStandardOnly`",
+  {
+    "comment": "Label with hyphens in 3rd and 4th position",
+    "input": "aa--",
+    "output": "aa--"
+  },
+  {
+    "input": "a†--",
+    "output": "xn--a---kp0a"
+  },
+  {
+    "input": "ab--c",
+    "output": "ab--c"
+  },
+  {
+    "comment": "Label with leading hyphen",
+    "input": "-x",
+    "output": "-x"
+  },
+  {
+    "input": "-†",
+    "output": "xn----xhn"
+  },
+  {
+    "input": "-x.xn--zca",
+    "output": "-x.xn--zca"
+  },
+  {
+    "input": "-x.ß",
+    "output": "-x.xn--zca"
+  },
+  {
+    "comment": "Label with trailing hyphen",
+    "input": "x-.xn--zca",
+    "output": "x-.xn--zca"
+  },
+  {
+    "input": "x-.ß",
+    "output": "x-.xn--zca"
+  },
+  {
+    "comment": "Empty labels",
+    "input": "x..xn--zca",
+    "output": "x..xn--zca"
+  },
+  {
+    "input": "x..ß",
+    "output": "x..xn--zca"
+  },
+  {
+    "comment": "Invalid Punycode",
+    "input": "xn--a",
+    "output": "xn--a"
+  },
+  {
+    "input": "xn--a.xn--zca",
+    "output": "xn--a.xn--zca"
+  },
+  {
+    "input": "xn--a.ß",
+    "output": null
+  },
+  {
+    "input": "xn--ls8h=",
+    "output": "xn--ls8h="
+  },
+  {
+    "comment": "Invalid Punycode (contains non-ASCII character)",
+    "input": "xn--tešla",
+    "output": null
+  },
+  {
+    "comment": "Valid Punycode",
+    "input": "xn--zca.xn--zca",
+    "output": "xn--zca.xn--zca"
+  },
+  {
+    "comment": "Mixed",
+    "input": "xn--zca.ß",
+    "output": "xn--zca.xn--zca"
+  },
+  {
+    "input": "ab--c.xn--zca",
+    "output": "ab--c.xn--zca"
+  },
+  {
+    "input": "ab--c.ß",
+    "output": "ab--c.xn--zca"
+  },
+  {
+    "comment": "CheckJoiners is true",
+    "input": "\u200D.example",
+    "output": null
+  },
+  {
+    "input": "xn--1ug.example",
+    "output": "xn--1ug.example"
+  },
+  {
+    "comment": "CheckBidi is true",
+    "input": "يa",
+    "output": null
+  },
+  {
+    "input": "xn--a-yoc",
+    "output": "xn--a-yoc"
+  },
+  {
+    "comment": "processing_option is Nontransitional_Processing",
+    "input": "ශ්‍රී",
+    "output": "xn--10cl1a0b660p"
+  },
+  {
+    "input": "نامه‌ای",
+    "output": "xn--mgba3gch31f060k"
+  },
+  {
+    "comment": "U+FFFD",
+    "input": "\uFFFD.com",
+    "output": null
+  },
+  {
+    "comment": "U+FFFD character encoded in Punycode",
+    "input": "xn--zn7c.com",
+    "output": "xn--zn7c.com"
+  },
+  {
+    "comment": "Label longer than 63 code points",
+    "input": "x01234567890123456789012345678901234567890123456789012345678901x",
+    "output": "x01234567890123456789012345678901234567890123456789012345678901x"
+  },
+  {
+    "input": "x01234567890123456789012345678901234567890123456789012345678901†",
+    "output": "xn--x01234567890123456789012345678901234567890123456789012345678901-6963b"
+  },
+  {
+    "input": "x01234567890123456789012345678901234567890123456789012345678901x.xn--zca",
+    "output": "x01234567890123456789012345678901234567890123456789012345678901x.xn--zca"
+  },
+  {
+    "input": "x01234567890123456789012345678901234567890123456789012345678901x.ß",
+    "output": "x01234567890123456789012345678901234567890123456789012345678901x.xn--zca"
+  },
+  {
+    "comment": "Domain excluding TLD longer than 253 code points",
+    "input": "01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.0123456789012345678901234567890123456789012345678.x",
+    "output": "01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.0123456789012345678901234567890123456789012345678.x"
+  },
+  {
+    "input": "01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.0123456789012345678901234567890123456789012345678.xn--zca",
+    "output": "01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.0123456789012345678901234567890123456789012345678.xn--zca"
+  },
+  {
+    "input": "01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.0123456789012345678901234567890123456789012345678.ß",
+    "output": "01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.01234567890123456789012345678901234567890123456789.0123456789012345678901234567890123456789012345678.xn--zca"
+  },
+  {
+    "comment": "IDNA ignored code points",
+    "input": "a\u00ADb",
+    "output": "ab"
+  },
+  {
+    "comment": "Interesting UseSTD3ASCIIRules=false cases",
+    "input": "≠",
+    "output": "xn--1ch"
+  },
+  {
+    "input": "≮",
+    "output": "xn--gdh"
+  },
+  {
+    "input": "≯",
+    "output": "xn--hdh"
+  },
+  {
+    "comment": "NFC normalization (forbidden < and > characters are normalized to valid ones)",
+    "input": "=\u0338",
+    "output": "xn--1ch"
+  },
+  {
+    "input": "<\u0338",
+    "output": "xn--gdh"
+  },
+  {
+    "input": ">\u0338",
+    "output": "xn--hdh"
+  },
+  {
+    "comment": "Same with inserted IDNA ignored code point",
+    "input": "=\u00AD\u0338",
+    "output": "xn--1ch"
+  },
+  {
+    "input": "<\u00AD\u0338",
+    "output": "xn--gdh"
+  },
+  {
+    "input": ">\u00AD\u0338",
+    "output": "xn--hdh"
+  },
+  "Tests below are from WebKit (fast/url/idna2003.html & fast/url/idna2008.html; contributed by Chris Weber back in 2011).",
+  {
+    "input": "fa\u00DF.de",
+    "output": "xn--fa-hia.de"
+  },
+  {
+    "input": "\u03B2\u03CC\u03BB\u03BF\u03C2.com",
+    "output": "xn--nxasmm1c.com"
+  },
+  {
+    "input": "\u0DC1\u0DCA\u200D\u0DBB\u0DD3.com",
+    "output": "xn--10cl1a0b660p.com"
+  },
+  {
+    "input": "\u0646\u0627\u0645\u0647\u200C\u0627\u06CC.com",
+    "output": "xn--mgba3gch31f060k.com"
+  },
+  {
+    "input": "www.loo\u0138out.net",
+    "output": "www.xn--looout-5bb.net"
+  },
+  {
+    "input": "\u15EF\u15EF\u15EF.lookout.net",
+    "output": "xn--1qeaa.lookout.net"
+  },
+  {
+    "input": "www.lookout.\u0441\u043E\u043C",
+    "output": "www.lookout.xn--l1adi"
+  },
+  {
+    "input": "www\u2025lookout.net",
+    "output": null
+  },
+  {
+    "input": "www.lookout\u2027net",
+    "output": "www.xn--lookoutnet-406e"
+  },
+  {
+    "input": "www.lookout.net\u2A7480",
+    "output": null,
+    "urlStandardOnly": true
+  },
+  {
+    "input": "www\u00A0.lookout.net",
+    "output": null,
+    "urlStandardOnly": true
+  },
+  {
+    "input": "\u1680lookout.net",
+    "output": null
+  },
+  {
+    "input": "\u001flookout.net",
+    "output": null,
+    "urlStandardOnly": true
+  },
+  {
+    "input": "look\u06DDout.net",
+    "output": null
+  },
+  {
+    "input": "look\u180Eout.net",
+    "output": "lookout.net"
+  },
+  {
+    "input": "look\u2060out.net",
+    "output": "lookout.net"
+  },
+  {
+    "input": "look\uFEFFout.net",
+    "output": "lookout.net"
+  },
+  {
+    "input": "look\uD83F\uDFFEout.net",
+    "output": null
+  },
+  {
+    "input": "look\uFFFAout.net",
+    "output": null
+  },
+  {
+    "input": "look\u2FF0out.net",
+    "output": null
+  },
+  {
+    "input": "look\u0341out.net",
+    "output": "xn--looout-kp7b.net"
+  },
+  {
+    "input": "look\u202Eout.net",
+    "output": null
+  },
+  {
+    "input": "look\u206Bout.net",
+    "output": "lookout.net"
+  },
+  {
+    "input": "look\uDB40\uDC01out.net",
+    "output": null
+  },
+  {
+    "input": "look\uDB40\uDC20out.net",
+    "output": null
+  },
+  {
+    "input": "look\u05BEout.net",
+    "output": null
+  },
+  {
+    "input": "B\u00FCcher.de",
+    "output": "xn--bcher-kva.de"
+  },
+  {
+    "input": "\u2665.net",
+    "output": "xn--g6h.net"
+  },
+  {
+    "input": "\u0378.net",
+    "output": null
+  },
+  {
+    "input": "\u04C0.com",
+    "output": "xn--s5a.com"
+  },
+  {
+    "input": "\uD87E\uDC68.com",
+    "output": "xn--snl.com"
+  },
+  {
+    "input": "\u2183.com",
+    "output": "xn--r5g.com"
+  },
+  {
+    "input": "look\u034Fout.net",
+    "output": "lookout.net"
+  },
+  {
+    "input": "gOoGle.com",
+    "output": "google.com"
+  },
+  {
+    "input": "\u09dc.com",
+    "output": "xn--15b8c.com"
+  },
+  {
+    "input": "\u1E9E.com",
+    "output": "xn--zca.com"
+  },
+  {
+    "input": "\u1E9E.foo.com",
+    "output": "xn--zca.foo.com"
+  },
+  {
+    "input": "-foo.bar.com",
+    "output": "-foo.bar.com"
+  },
+  {
+    "input": "foo-.bar.com",
+    "output": "foo-.bar.com"
+  },
+  {
+    "input": "ab--cd.com",
+    "output": "ab--cd.com"
+  },
+  {
+    "input": "xn--0.com",
+    "output": "xn--0.com"
+  },
+  {
+    "input": "foo\u0300.bar.com",
+    "output": "xn--fo-3ja.bar.com"
+  }
+]

--- a/tests/to_ascii_tests.cpp
+++ b/tests/to_ascii_tests.cpp
@@ -189,6 +189,16 @@ TEST(to_ascii_tests, ascii_xn_carveout) {
   // Bare ACE prefix: the Punycode payload is empty. Previously rejected.
   EXPECT_EQ(ada::idna::to_ascii("xn--"), "xn--");
 
+  // Invalid Punycode payload (WPT toascii.json "Invalid Punycode"): the ACE
+  // segment does not decode. Previously rejected; under the carve-out the
+  // ASCII input is returned lowercased. This is the case that broke Ada's
+  // URLPattern hostname unit test after the 0.6.0 bump
+  // (hostname "xn--a" must be accepted as "xn--a").
+  EXPECT_EQ(ada::idna::to_ascii("xn--a"), "xn--a");
+  EXPECT_EQ(ada::idna::to_ascii("XN--A"), "xn--a");
+  // Same invalid ACE as a label of a larger domain (IdnaTestV2 V7).
+  EXPECT_EQ(ada::idna::to_ascii("xn--a.pt"), "xn--a.pt");
+
   // ContextJ (C1): xn--ab-j1t decodes to "a\u200Cb" (ZWNJ not preceded by a
   // virama). Previously rejected; now accepted as-is.
   EXPECT_EQ(ada::idna::to_ascii("xn--ab-j1t"), "xn--ab-j1t");
@@ -211,6 +221,7 @@ TEST(to_ascii_tests, ascii_xn_carveout) {
   // Idempotency: to_ascii of an ASCII result is stable.
   const std::string once = ada::idna::to_ascii("xn--ab-j1t");
   EXPECT_EQ(ada::idna::to_ascii(once), once);
+  EXPECT_EQ(ada::idna::to_ascii("xn--a"), "xn--a");
 }
 
 // The ASCII carve-out must NOT relax validation for non-ASCII inputs: those go

--- a/tests/to_ascii_tests.cpp
+++ b/tests/to_ascii_tests.cpp
@@ -179,54 +179,186 @@ TEST(to_ascii_tests, bidi_regression) {
       << "multi-label should fail";
 }
 
+// Helper: domain-to-ASCII as URL Standard callers use it (to_ascii + forbidden
+// domain code point filter). Empty string means failure.
+static std::string domain_to_ascii(std::string_view input) {
+  std::string out = ada::idna::to_ascii(input);
+  if (ada::idna::contains_forbidden_domain_code_point(out)) {
+    return "";
+  }
+  return out;
+}
+
 // Regression tests for the WHATWG URL "domain to ASCII" web-compatibility
 // carve-out: when the input domain is an ASCII string (beStrict = false), the
 // result is the input lowercased, regardless of Unicode ToASCII's outcome. An
 // ACE ("xn--") label may decode yet still fail IDNA validity criteria and must
 // nevertheless be accepted as-is.
 // See https://url.spec.whatwg.org/#concept-domain-to-ascii
+//
+// Cases below are drawn from:
+// - WPT toascii.json (vendored as fixtures/toascii.json)
+// - WPT IdnaTestV2.json carve-out flips (null -> pass-through)
+// - WPT urltestdata.json hostnames that flipped failure -> success in Ada
+// - WPT setters_tests.json host/hostname "xn--" acceptance
+// - Ada URLPattern hostname unit tests (xn--a / XN--A)
 TEST(to_ascii_tests, ascii_xn_carveout) {
+  // --- Bare / empty ACE payload ---
   // Bare ACE prefix: the Punycode payload is empty. Previously rejected.
+  // WPT setters_tests / urltestdata: host "xn--" is accepted.
   EXPECT_EQ(ada::idna::to_ascii("xn--"), "xn--");
+  EXPECT_EQ(domain_to_ascii("xn--"), "xn--");
+  EXPECT_EQ(ada::idna::to_ascii("XN--"), "xn--");
+  // Trailing hyphen only in the ACE payload.
+  EXPECT_EQ(ada::idna::to_ascii("xn---"), "xn---");
 
-  // Invalid Punycode payload (WPT toascii.json "Invalid Punycode"): the ACE
-  // segment does not decode. Previously rejected; under the carve-out the
-  // ASCII input is returned lowercased. This is the case that broke Ada's
-  // URLPattern hostname unit test after the 0.6.0 bump
-  // (hostname "xn--a" must be accepted as "xn--a").
+  // --- Invalid Punycode (decode failure) ---
+  // WPT toascii.json "Invalid Punycode": the ACE segment does not decode.
+  // Ada URLPattern hostname "xn--a" must be accepted as "xn--a".
   EXPECT_EQ(ada::idna::to_ascii("xn--a"), "xn--a");
+  EXPECT_EQ(domain_to_ascii("xn--a"), "xn--a");
   EXPECT_EQ(ada::idna::to_ascii("XN--A"), "xn--a");
-  // Same invalid ACE as a label of a larger domain (IdnaTestV2 V7).
+  EXPECT_EQ(ada::idna::to_ascii("Xn--a"), "xn--a");
+  // Same invalid ACE as a label of a larger domain (IdnaTestV2 V7 / toascii).
   EXPECT_EQ(ada::idna::to_ascii("xn--a.pt"), "xn--a.pt");
+  EXPECT_EQ(ada::idna::to_ascii("xn--a.xn--zca"), "xn--a.xn--zca");
+  // Invalid ACE with trailing junk that remains ASCII (toascii.json).
+  EXPECT_EQ(ada::idna::to_ascii("xn--ls8h="), "xn--ls8h=");
+  // Invalid ACE that is pure digits after prefix (IdnaTestV2 / toascii).
+  EXPECT_EQ(ada::idna::to_ascii("xn--0"), "xn--0");
+  EXPECT_EQ(ada::idna::to_ascii("xn--0.com"), "xn--0.com");
+  EXPECT_EQ(ada::idna::to_ascii("xn--0.pt"), "xn--0.pt");
 
+  // --- Decode succeeds but IDNA validity fails (ContextJ / mapped / etc.) ---
   // ContextJ (C1): xn--ab-j1t decodes to "a\u200Cb" (ZWNJ not preceded by a
   // virama). Previously rejected; now accepted as-is.
   EXPECT_EQ(ada::idna::to_ascii("xn--ab-j1t"), "xn--ab-j1t");
+  // ContextJ (C2): ZWJ variant.
+  EXPECT_EQ(ada::idna::to_ascii("xn--ab-m1t"), "xn--ab-m1t");
+  // V1 / other validity failures that remain pure-ASCII ACE forms.
+  EXPECT_EQ(ada::idna::to_ascii("xn--u-ccb"), "xn--u-ccb");
+  EXPECT_EQ(ada::idna::to_ascii("xn--acom-0w1b"), "xn--acom-0w1b");
+  EXPECT_EQ(ada::idna::to_ascii("xn--a-ecp.ru"), "xn--a-ecp.ru");
+  EXPECT_EQ(ada::idna::to_ascii("xn--xn--a--gua.pt"), "xn--xn--a--gua.pt");
+  // Joiners ACE still accepted when input is pure ASCII (toascii CheckJoiners).
+  EXPECT_EQ(ada::idna::to_ascii("xn--1ug.example"), "xn--1ug.example");
+  EXPECT_EQ(ada::idna::to_ascii("xn--1ug"), "xn--1ug");
+  // Bidi ACE form accepted as ASCII (toascii CheckBidi counterpart).
+  EXPECT_EQ(ada::idna::to_ascii("xn--a-yoc"), "xn--a-yoc");
+  // U+FFFD encoded in Punycode is pure ASCII input -> accepted (toascii).
+  EXPECT_EQ(ada::idna::to_ascii("xn--zn7c.com"), "xn--zn7c.com");
 
   // Decoded label has code points with "mapped" status (enclosed CJK), so the
   // ACE form is non-canonical. Previously rejected; now accepted as-is.
+  // From Ada WPT urltestdata.json (failure -> success under carve-out).
   EXPECT_EQ(ada::idna::to_ascii("a.b.c.xn--pokxncvks"), "a.b.c.xn--pokxncvks");
+  EXPECT_EQ(ada::idna::to_ascii("10.0.0.xn--pokxncvks"),
+            "10.0.0.xn--pokxncvks");
 
   // The URL spec's own example: xn--8i7caa decodes to fullwidth "www", whose
   // code points have "mapped" status.
   EXPECT_EQ(ada::idna::to_ascii("xn--8i7caa"), "xn--8i7caa");
 
-  // Mixed/upper-case ACE prefixes must be lowercased.
+  // Double-encoded ACE prefix forms that remain pure ASCII (IdnaTestV2 flips).
+  EXPECT_EQ(ada::idna::to_ascii("xn--xn--bss-7z6ccid"), "xn--xn--bss-7z6ccid");
+  EXPECT_EQ(ada::idna::to_ascii("xn--xn---epa"), "xn--xn---epa");
+  EXPECT_EQ(ada::idna::to_ascii("xn--ASCII-"), "xn--ascii-");
+  EXPECT_EQ(ada::idna::to_ascii("xn--unicode-.org"), "xn--unicode-.org");
+
+  // Long ACE labels that previously failed validity (IdnaTestV2 C1/C2/A4).
+  EXPECT_EQ(
+      ada::idna::to_ascii(
+          "1.xn--"
+          "assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssss"
+          "ssssssssysssssssssssssssssz-pxq1419aa69989dba9gc"),
+      "1.xn--"
+      "assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssss"
+      "ssssysssssssssssssssssz-pxq1419aa69989dba9gc");
+  EXPECT_EQ(
+      ada::idna::to_ascii(
+          "1.xn--abcdexyz-qyacaaabaaaaaaabaaaaaaaaabaaaaaaaaabaaaaaaaa010ze"
+          "2isb1140zba8cc"),
+      "1.xn--abcdexyz-qyacaaabaaaaaaabaaaaaaaaabaaaaaaaaabaaaaaaaa010ze2isb"
+      "1140zba8cc");
+
+  // --- Case folding of ACE prefixes (urltestdata mixed-case hostnames) ---
   EXPECT_EQ(ada::idna::to_ascii("a.b.c.XN--pokxncvks"), "a.b.c.xn--pokxncvks");
   EXPECT_EQ(ada::idna::to_ascii("a.b.c.Xn--pokxncvks"), "a.b.c.xn--pokxncvks");
+  EXPECT_EQ(ada::idna::to_ascii("10.0.0.XN--pokxncvks"),
+            "10.0.0.xn--pokxncvks");
+  EXPECT_EQ(ada::idna::to_ascii("10.0.0.xN--pokxncvks"),
+            "10.0.0.xn--pokxncvks");
 
-  // A plain already-ASCII domain is returned lowercased.
+  // --- Ordinary pure-ASCII domains ---
   EXPECT_EQ(ada::idna::to_ascii("EXAMPLE.COM"), "example.com");
+  EXPECT_EQ(ada::idna::to_ascii("gOoGle.com"), "google.com");
+  // Labels with hyphens in 3rd/4th position (toascii.json, UseSTD3=false).
+  EXPECT_EQ(ada::idna::to_ascii("aa--"), "aa--");
+  EXPECT_EQ(ada::idna::to_ascii("ab--c"), "ab--c");
+  EXPECT_EQ(ada::idna::to_ascii("ab--cd.com"), "ab--cd.com");
+  // Leading / trailing hyphen labels (toascii.json).
+  EXPECT_EQ(ada::idna::to_ascii("-x"), "-x");
+  EXPECT_EQ(ada::idna::to_ascii("-foo.bar.com"), "-foo.bar.com");
+  EXPECT_EQ(ada::idna::to_ascii("foo-.bar.com"), "foo-.bar.com");
+  // Empty labels between dots (toascii.json).
+  EXPECT_EQ(ada::idna::to_ascii("x..xn--zca"), "x..xn--zca");
+  EXPECT_EQ(ada::idna::to_ascii("-x.xn--zca"), "-x.xn--zca");
+  EXPECT_EQ(ada::idna::to_ascii("x-.xn--zca"), "x-.xn--zca");
+  EXPECT_EQ(ada::idna::to_ascii("ab--c.xn--zca"), "ab--c.xn--zca");
+  EXPECT_EQ(ada::idna::to_ascii("xn--zca.xn--zca"), "xn--zca.xn--zca");
 
-  // Idempotency: to_ascii of an ASCII result is stable.
+  // Overlong labels / domains (toascii.json): still pure ASCII -> accepted.
+  EXPECT_EQ(
+      ada::idna::to_ascii(
+          "x01234567890123456789012345678901234567890123456789012345678901"
+          "x"),
+      "x01234567890123456789012345678901234567890123456789012345678901x");
+  EXPECT_EQ(
+      ada::idna::to_ascii(
+          "x01234567890123456789012345678901234567890123456789012345678901x."
+          "xn--zca"),
+      "x01234567890123456789012345678901234567890123456789012345678901x.xn--"
+      "zca");
+
+  // --- Idempotency ---
   const std::string once = ada::idna::to_ascii("xn--ab-j1t");
   EXPECT_EQ(ada::idna::to_ascii(once), once);
   EXPECT_EQ(ada::idna::to_ascii("xn--a"), "xn--a");
+  EXPECT_EQ(ada::idna::to_ascii(ada::idna::to_ascii("a.b.c.XN--pokxncvks")),
+            "a.b.c.xn--pokxncvks");
+  EXPECT_EQ(ada::idna::to_ascii(ada::idna::to_ascii("XN--")), "xn--");
+}
+
+// Table-driven mirror of the Ada urltestdata / setters carve-out hostnames:
+// every entry was previously failure (or rejected by set_host) and must now
+// round-trip through to_ascii as a lowercased ASCII domain.
+TEST(to_ascii_tests, ada_wpt_urltestdata_carveout_hosts) {
+  static constexpr std::pair<const char*, const char*> kCases[] = {
+      // urltestdata.json: mapped-status ACE labels
+      {"a.b.c.xn--pokxncvks", "a.b.c.xn--pokxncvks"},
+      {"10.0.0.xn--pokxncvks", "10.0.0.xn--pokxncvks"},
+      {"a.b.c.XN--pokxncvks", "a.b.c.xn--pokxncvks"},
+      {"a.b.c.Xn--pokxncvks", "a.b.c.xn--pokxncvks"},
+      {"10.0.0.XN--pokxncvks", "10.0.0.xn--pokxncvks"},
+      {"10.0.0.xN--pokxncvks", "10.0.0.xn--pokxncvks"},
+      // urltestdata.json / setters_tests.json: bare xn--
+      {"xn--", "xn--"},
+      {"XN--", "xn--"},
+      // file:// and https:// hosts that flipped failure -> success
+      {"xn--", "xn--"},
+  };
+  for (const auto& [input, expected] : kCases) {
+    SCOPED_TRACE(input);
+    EXPECT_EQ(domain_to_ascii(input), expected);
+    // Second application is a no-op (already lowercased ASCII).
+    EXPECT_EQ(domain_to_ascii(domain_to_ascii(input)), expected);
+  }
 }
 
 // The ASCII carve-out must NOT relax validation for non-ASCII inputs: those go
 // through full UTS#46 validation. Contrast xn--ab-j1t (ASCII, accepted above)
 // with its decoded form "a\u200Cb" supplied directly (non-ASCII, rejected).
+// Also covers toascii.json cases that remain failures for non-ASCII input.
 TEST(to_ascii_tests, non_ascii_inputs_still_validated) {
   // ZWNJ (U+200C) without a preceding virama: ContextJ (C1) violation.
   EXPECT_TRUE(ada::idna::to_ascii("a\u200Cb").empty())
@@ -235,4 +367,25 @@ TEST(to_ascii_tests, non_ascii_inputs_still_validated) {
   // LTR label containing an RTL code point: Bidi rule violation.
   EXPECT_TRUE(ada::idna::to_ascii("a\u05D0").empty())
       << "non-ASCII Bidi violation should still fail";
+
+  // toascii.json: CheckJoiners is true — bare ZWJ label fails.
+  EXPECT_TRUE(ada::idna::to_ascii("\u200D.example").empty())
+      << "non-ASCII ZWJ joiner should still fail";
+
+  // toascii.json: CheckBidi is true — Arabic + Latin fails.
+  EXPECT_TRUE(ada::idna::to_ascii("يa").empty())
+      << "non-ASCII Bidi (Arabic+Latin) should still fail";
+
+  // toascii.json: U+FFFD literal fails; contrast ACE form xn--zn7c.com above.
+  EXPECT_TRUE(ada::idna::to_ascii("\uFFFD.com").empty())
+      << "U+FFFD in domain should still fail";
+
+  // toascii.json: Invalid Punycode containing non-ASCII (xn--tešla) fails.
+  // UTF-8 for "xn--tešla" (š = U+0161 = C5 A1).
+  EXPECT_TRUE(ada::idna::to_ascii("xn--te\xc5\xa1la").empty())
+      << "invalid punycode with non-ASCII must not use the ASCII carve-out";
+
+  // toascii.json: xn--a.ß mixes invalid ACE with non-ASCII sharp-s -> fail.
+  EXPECT_TRUE(ada::idna::to_ascii("xn--a.\xc3\x9f").empty())
+      << "mixed invalid ACE + non-ASCII label should still fail";
 }

--- a/tests/wpt_tests.cpp
+++ b/tests/wpt_tests.cpp
@@ -133,3 +133,97 @@ TEST_F(IdnaTestV2, ToAscii) {
     }
   }
 }
+
+// WPT toascii.json — assorted IDNA / domain-to-ASCII cases that IdnaTestV2 may
+// not cover. Vendored from web-platform-tests (also used by Ada).
+// Mirrors Ada's unicode::to_ascii: to_ascii + forbidden-domain-code-point
+// filter. See
+// https://github.com/web-platform-tests/wpt/blob/master/url/resources/toascii.json
+TEST(ToAsciiWpt, ToAscii) {
+  const char* filename = "fixtures/toascii.json";
+  if (!std::filesystem::exists(filename)) {
+    GTEST_SKIP() << "Test file not found: " << filename;
+  }
+
+  ondemand::parser parser;
+  padded_string json;
+  try {
+    json = padded_string::load(filename);
+    std::cout << "  loaded " << filename << " (" << json.size() << " B)"
+              << std::endl;
+  } catch (const simdjson_error& e) {
+    FAIL() << "Failed to load JSON file: " << e.what();
+  }
+
+  ondemand::document doc;
+  try {
+    doc = parser.iterate(json);
+  } catch (const simdjson_error& e) {
+    FAIL() << "Failed to parse JSON: " << e.what();
+  }
+
+  size_t cases = 0;
+  for (auto element : doc.get_array()) {
+    if (element.type() == ondemand::json_type::string) {
+      continue;  // comments
+    }
+
+    ondemand::object object;
+    try {
+      object = element.get_object();
+    } catch (const simdjson_error& e) {
+      ADD_FAILURE() << "Failed to get object: " << e.what();
+      continue;
+    }
+
+    auto json_string =
+        std::string(std::string_view(simdjson::to_json_string(object)));
+
+    std::string_view input;
+    try {
+      input = object["input"].get_string();
+    } catch (const simdjson_error& e) {
+      // Invalid Unicode in the JSON string — skip (Ada does the same).
+      std::cout << "  skip invalid input encoding: " << e.what()
+                << " for: " << json_string << std::endl;
+      continue;
+    }
+
+    SCOPED_TRACE("Test case: " + json_string);
+
+    std::string output = ada::idna::to_ascii(input);
+    if (ada::idna::contains_forbidden_domain_code_point(output)) {
+      output = "";
+    }
+
+    auto expected_output = object["output"];
+    ++cases;
+
+    if (expected_output.is_null()) {
+      EXPECT_TRUE(output.empty())
+          << "Expected failure (null) for input but got: " << output
+          << " case: " << json_string;
+    } else if (expected_output.type() == ondemand::json_type::string) {
+      std::string_view str_expected_output;
+      try {
+        str_expected_output = expected_output.get_string();
+      } catch (const simdjson_error& e) {
+        ADD_FAILURE() << "Failed to get expected output string: " << e.what();
+        continue;
+      }
+      EXPECT_EQ(output, str_expected_output)
+          << "toascii mismatch for case: " << json_string;
+
+      // Idempotency on successful results: applying to_ascii again is stable.
+      if (!output.empty()) {
+        std::string again = ada::idna::to_ascii(output);
+        if (ada::idna::contains_forbidden_domain_code_point(again)) {
+          again = "";
+        }
+        EXPECT_EQ(again, output) << "to_ascii not idempotent for: " << output;
+      }
+    }
+  }
+  EXPECT_GT(cases, 50u) << "expected toascii.json to contribute many cases";
+  std::cout << "  ran " << cases << " toascii.json cases" << std::endl;
+}


### PR DESCRIPTION
## Summary
Ports the Ada PR [#1137](https://github.com/ada-url/ada/pull/1137) / WPT regression surface for the WHATWG `beStrict=false` ASCII domain-to-ASCII carve-out into ada-url/idna.

### Fixtures
- **`tests/fixtures/toascii.json`** — full WPT `toascii.json` (87 cases), same file Ada runs.

### Runners
- **`ToAsciiWpt.ToAscii`** — drives `toascii.json` through `to_ascii` + forbidden-domain-code-point filter (matches Ada `unicode::to_ascii`), plus idempotency checks on successes.

### Unit tests (`to_ascii_tests`)
- **`ascii_xn_carveout`** — expanded with:
  - bare / empty ACE (`xn--`, `xn---`)
  - invalid punycode (`xn--a`, `XN--A`, `xn--a.pt`, `xn--ls8h=`, `xn--0*`)
  - decode-ok / validity-fail ACE (ContextJ C1/C2, mapped-status `xn--pokxncvks`, `xn--8i7caa`, joiners, Bidi ACE forms, U+FFFD ACE)
  - double-encoded / long IdnaTestV2 labels
  - case folding of ACE prefixes (urltestdata mixed-case hosts)
  - ordinary ASCII edge cases (hyphens, empty labels, overlong labels)
  - idempotency
- **`ada_wpt_urltestdata_carveout_hosts`** — table of Ada urltestdata/setters hosts that flipped failure → success
- **`non_ascii_inputs_still_validated`** — ensures carve-out stays ASCII-only (ZWJ, Bidi, U+FFFD, `xn--tešla`, `xn--a.ß`)

No production code change.

## Test plan
- [x] `ctest --test-dir build` — 41/41 pass (incl. `ToAsciiWpt.ToAscii`, expanded unit tests)
- [x] `ToAsciiWpt.ToAscii` reports `ran 87 toascii.json cases`