### PR TITLE
fix is_already_nfc for a composite starter before a lower-class mark

### DIFF
--- a/src/normalization.cpp
+++ b/src/normalization.cpp
@@ -219,6 +219,22 @@ static bool would_compose(std::u32string_view input) noexcept {
   return false;
 }
 
+// Trailing canonical combining class of a character: the combining class of the
+// last code point of its canonical decomposition, or the character's own class
+// when it has none. A precomposed starter such as U+00E1 (a + U+0301, class
+// 230) has class 0 but a nonzero trailing class, so a following mark of lower
+// class reorders past the hidden mark during normalization.
+static uint8_t trailing_ccc(char32_t c) noexcept {
+  const size_t length = canonical_decomp_length(c);
+  if (length == 0) {
+    return get_ccc(c);
+  }
+  const uint16_t* const decomposition =
+      decomposition_block_row(decomposition_index[c >> 8]) + (c % 256);
+  const size_t base = decomposition[0] >> 2;
+  return get_ccc(decomposition_data[base + length - 1]);
+}
+
 bool is_already_nfc(std::u32string_view input) noexcept {
   if (input.empty()) {
     return true;
@@ -233,14 +249,16 @@ bool is_already_nfc(std::u32string_view input) noexcept {
       return false;
     }
   }
-  // 2) Combining marks already in canonical order.
+  // 2) Combining marks already in canonical order. prev_ccc carries the
+  //    trailing class of the previous character's canonical decomposition so a
+  //    composite starter followed by a lower-class mark is caught.
   uint8_t prev_ccc = 0;
   for (char32_t c : input) {
     uint8_t ccc = get_ccc(c);
     if (ccc != 0 && prev_ccc > ccc) {
       return false;
     }
-    prev_ccc = ccc;
+    prev_ccc = trailing_ccc(c);
   }
   // 3) No pairwise composition would apply (including Hangul L+V / LV+T).
   return !would_compose(input);

--- a/tests/to_ascii_tests.cpp
+++ b/tests/to_ascii_tests.cpp
@@ -106,6 +106,18 @@ TEST(to_ascii_tests, special_cases) {
       << "Replacement character in domain should result in empty string";
 }
 
+TEST(to_ascii_tests, nfc_reorders_precomposed_starter) {
+  // A precomposed starter followed by a combining mark of lower combining class
+  // is not in NFC: normalization decomposes the starter and reorders the marks.
+  // U+00E1 (a + acute, class 230) then U+0323 (dot below, class 220) normalizes
+  // to U+1EA1 (a + dot below) with the acute floating -> xn--lsa752l.
+  ASSERT_EQ(ada::idna::to_ascii("\xc3\xa1\xcc\xa3"), "xn--lsa752l")
+      << "acute+dot-below should reorder to NFC before punycode";
+  // U+015A (S + acute, class 230) then U+0327 (cedilla, class 202).
+  ASSERT_EQ(ada::idna::to_ascii("\xc5\x9a\xcc\xa7"), "xn--nga05f")
+      << "acute+cedilla should reorder to NFC before punycode";
+}
+
 TEST(to_ascii_tests, comma_test) {
   ASSERT_FALSE(ada::idna::to_ascii("128.0,0.1").empty());
 }


### PR DESCRIPTION
The NFC quick check `is_already_nfc` in `src/normalization.cpp` tracks canonical ordering with each character's own combining class. A precomposed starter such as U+00E1 (a + U+0301, class 230) has class 0 but a canonical decomposition ending in a nonzero-class mark. When it is followed by a mark of lower class (U+0323 dot below, class 220) the string is not NFC: normalization decomposes the starter, reorders dot below ahead of acute and recomposes a+dot to U+1EA1 with the acute floating. The quick check reported NFC anyway, so `normalize` left the input untouched and `to_ascii` produced the wrong A-label, turning `ạ́` (U+00E1 U+0323) into `xn--1ca07i` instead of `xn--lsa752l`.

The fix adds a small `trailing_ccc` helper returning the combining class of the last code point of a character's canonical decomposition and carries that in `prev_ccc`, so a composite starter ahead of a lower-class mark is caught. It is conservative: it can only make the quick check defer to the full normalization path, never skip it wrongly.

Found while diffing host serialization against another URL implementation over random Unicode labels. Added a regression test in `tests/to_ascii_tests.cpp` (U+00E1 U+0323 -> xn--lsa752l and U+015A U+0327 -> xn--nga05f); the suite stays green.

This is the upstream equivalent of ada-url/ada#1226.