### PR TITLE
fix Hangul LV syllable + trailing jamo composition in NFC

### DIFF
--- a/src/normalization.cpp
+++ b/src/normalization.cpp
@@ -168,7 +168,7 @@ static bool would_compose(std::u32string_view input) noexcept {
       continue;
     }
     if (current >= hangul_sbase && current < hangul_sbase + hangul_scount) {
-      if ((current - hangul_sbase) % hangul_tcount &&
+      if ((current - hangul_sbase) % hangul_tcount == 0 &&
           input_count + 1 < input.size() &&
           input[input_count + 1] > hangul_tbase &&
           input[input_count + 1] < hangul_tbase + hangul_tcount) {
@@ -292,7 +292,7 @@ void compose(std::u32string& input) {
       }
     } else if (input[input_count] >= hangul_sbase &&
                input[input_count] < hangul_sbase + hangul_scount) {
-      if ((input[input_count] - hangul_sbase) % hangul_tcount &&
+      if ((input[input_count] - hangul_sbase) % hangul_tcount == 0 &&
           input_count + 1 < input.size() &&
           input[input_count + 1] > hangul_tbase &&
           input[input_count + 1] < hangul_tbase + hangul_tcount) {

--- a/tests/safety_tests.cpp
+++ b/tests/safety_tests.cpp
@@ -101,3 +101,19 @@ TEST(Safety, IsAlreadyNfc) {
   EXPECT_TRUE(ada::idna::is_already_nfc(precomposed));
   EXPECT_FALSE(ada::idna::is_already_nfc(decomposed));
 }
+
+TEST(Safety, ComposesHangulLvPlusTrailingJamo) {
+  ASSERT_TRUE(ada::idna::ensure_tables());
+  // A precomposed LV syllable (SIndex % TCount == 0) followed by a trailing
+  // jamo composes to the LVT syllable under NFC.
+  //   U+AC00 (가, LV) + U+11A8 (ᆨ, T) -> U+AC01 (각)
+  std::u32string lv_plus_t = {0xAC00, 0x11A8};
+  EXPECT_FALSE(ada::idna::is_already_nfc(lv_plus_t));
+  ASSERT_TRUE(ada::idna::normalize(lv_plus_t));
+  EXPECT_EQ(lv_plus_t, std::u32string({0xAC01}));
+
+  //   U+C4D4 (LV) + U+11B6 (T) -> U+C4E3
+  std::u32string lv_plus_t2 = {0xC4D4, 0x11B6};
+  ASSERT_TRUE(ada::idna::normalize(lv_plus_t2));
+  EXPECT_EQ(lv_plus_t2, std::u32string({0xC4E3}));
+}


### PR DESCRIPTION
would_compose and compose gate Hangul LV+T composition on (syllable - SBase) % TCount being nonzero, but an LV syllable has remainder zero, so a precomposed LV syllable followed by a trailing jamo is never recombined. is_already_nfc then reports the sequence as NFC and to_ascii emits the decomposed label, so canonically equivalent inputs map to different A-labels: to_ascii of U+C4D4 U+11B6 gives xn--5ud1282g instead of xn--pb5b. Requiring the remainder to be zero at both sites composes LV+T back into the LVT syllable.